### PR TITLE
[FEAT] 안드로이드 로그 디버그모드 관리

### DIFF
--- a/Near/app/src/main/java/com/alarmy/near/utils/logger/NearLog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/utils/logger/NearLog.kt
@@ -3,119 +3,97 @@ package com.alarmy.near.utils.logger
 import android.util.Log
 import com.alarmy.near.BuildConfig
 
-private const val TAG = "Near"
-private const val LOGGER_FILE_NAME = "NearLog.kt"
+object NearLog {
+    private const val TAG = "Near"
+    private const val LOGGER_FILE_NAME = "NearLog.kt"
 
-private fun buildLogMessage(message: String): String {
-    return try {
-        val stackTrace = Thread.currentThread().stackTrace
+    private fun buildLogMessage(message: String): String =
+        runCatching {
+            val stackTrace = Thread.currentThread().stackTrace
 
-        // 스택 트레이스를 순회하며 로거 파일이 아닌 첫 번째 호출자를 찾습니다
-        // 인덱스 0: Thread.getStackTrace()
-        // 인덱스 1: 현재 함수 (buildLogMessage)
-        // 인덱스 2~: 로그 함수들 (logd, loge 등)
-        // 그 이후: 실제 호출자
-        val callerElement =
-            stackTrace.drop(2).firstOrNull { element ->
-                element.fileName != LOGGER_FILE_NAME
-            }
+            // 스택 트레이스를 순회하며 로거 파일이 아닌 첫 번째 호출자를 찾습니다
+            // 인덱스 0: Thread.getStackTrace()
+            // 인덱스 1: 현재 함수 (buildLogMessage)
+            // 인덱스 2~: 로그 함수들 (d, e 등)
+            // 그 이후: 실제 호출자
+            val callerElement =
+                stackTrace.drop(2).firstOrNull { element ->
+                    element.fileName != LOGGER_FILE_NAME
+                } ?: throw IllegalStateException("Caller not found")
 
-        if (callerElement == null) {
-            return "[CallerNotFound] $message"
+            val fileName =
+                callerElement.fileName
+                    ?.substringBeforeLast('.')
+                    ?: "Unknown"
+
+            val methodName = callerElement.methodName ?: "unknownMethod"
+            val lineNumber = callerElement.lineNumber
+            val originalFileName = callerElement.fileName ?: "Unknown"
+
+            "[$fileName::$methodName ($originalFileName:$lineNumber)] $message"
+        }.getOrElse { exception ->
+            // 스택 트레이스 분석 실패 시 간단한 포맷으로 대체하여 로깅 기능 유지
+            "[LogError:${exception.javaClass.simpleName}] $message"
         }
 
-        val fileName =
-            callerElement.fileName
-                ?.substringBeforeLast('.')
-                ?: "Unknown"
+    // 디버그 모드 확인
+    private fun isLoggingEnabled(): Boolean = BuildConfig.DEBUG
 
-        val methodName = callerElement.methodName ?: "unknownMethod"
-        val lineNumber = callerElement.lineNumber
-        val originalFileName = callerElement.fileName ?: "Unknown"
+    /**
+     * 공통 로그 출력 함수
+     * 모든 로그 레벨에서 공통으로 사용되는 로직을 통합합니다
+     */
+    private fun writeLog(
+        level: Int,
+        tag: String,
+        message: String,
+        throwable: Throwable? = null,
+    ) {
+        if (!isLoggingEnabled()) return
 
-        "[$fileName::$methodName ($originalFileName:$lineNumber)] $message"
-    } catch (exception: Exception) {
-        "[LogError:${exception.javaClass.simpleName}] $message"
+        val formattedMessage = buildLogMessage(message)
+
+        when (level) {
+            Log.VERBOSE -> Log.v(tag, formattedMessage)
+            Log.DEBUG -> Log.d(tag, formattedMessage)
+            Log.INFO -> Log.i(tag, formattedMessage)
+            Log.WARN -> Log.w(tag, formattedMessage)
+            Log.ERROR -> Log.e(tag, formattedMessage, throwable)
+        }
     }
-}
 
-/**
- * 디버그 모드인지 확인합니다
- */
-private fun isLoggingEnabled(): Boolean = BuildConfig.DEBUG
+    // Verbose 로그
+    fun v(
+        message: String,
+        tag: String = TAG,
+    ) = writeLog(Log.VERBOSE, tag, message)
 
-// Verbose 로그
-fun logv(
-    message: String,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.v(tag, buildLogMessage(message))
-}
+    // Debug 로그
+    fun d(
+        message: String,
+        tag: String = TAG,
+    ) = writeLog(Log.DEBUG, tag, message)
 
-// Debug 로그
-fun logd(
-    message: String,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.d(tag, buildLogMessage(message))
-}
+    // Info 로그
+    fun i(
+        message: String,
+        tag: String = TAG,
+    ) = writeLog(Log.INFO, tag, message)
 
-// Info 로그
-fun logi(
-    message: String,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.i(tag, buildLogMessage(message))
-}
+    // Warning 로그
+    fun w(
+        message: String,
+        tag: String = TAG,
+    ) = writeLog(Log.WARN, tag, message)
 
-// Warning 로그
-fun logw(
-    message: String,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.w(tag, buildLogMessage(message))
-}
-
-// Error 로그
-fun loge(
-    message: String,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.e(tag, buildLogMessage(message))
-}
-
-// Error 로그 (이름 포함)
-fun loge(
-    name: String,
-    message: String,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.e(tag, buildLogMessage("$name: $message"))
-}
-
-// Error 로그 (예외 포함)
-fun loge(
-    message: String,
-    throwable: Throwable,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.e(tag, buildLogMessage(message), throwable)
-}
-
-// Error 로그 (이름과 예외 모두 포함)
-fun loge(
-    name: String,
-    message: String,
-    throwable: Throwable,
-    tag: String = TAG,
-) {
-    if (!isLoggingEnabled()) return
-    Log.e(tag, buildLogMessage("$name: $message"), throwable)
+    // Error 로그
+    fun e(
+        message: String,
+        throwable: Throwable? = null,
+        name: String? = null,
+        tag: String = TAG,
+    ) {
+        val finalMessage = if (name != null) "$name: $message" else message
+        writeLog(Log.ERROR, tag, finalMessage, throwable)
+    }
 }

--- a/Near/app/src/main/java/com/alarmy/near/utils/logger/NearLog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/utils/logger/NearLog.kt
@@ -1,0 +1,135 @@
+package com.alarmy.near.utils.logger
+
+import android.util.Log
+import com.alarmy.near.BuildConfig
+
+private const val TAG = "Near"
+private const val STACK_TRACE_INDEX = 5
+
+/**
+ * 호출자 정보를 포함한 로그 메시지를 생성합니다
+ * 스택 트레이스 추출에 실패하면 원본 메시지를 반환합니다
+ */
+private fun buildLogMessage(message: String): String {
+    return try {
+        val stackTrace = Thread.currentThread().stackTrace
+
+        // 실제 호출자를 찾기 위해 스택을 순회
+        for (i in 4 until stackTrace.size) {
+            val element = stackTrace[i]
+            val fileName = element.fileName ?: continue
+            val methodName = element.methodName ?: continue
+
+            // 로그 관련 메서드들을 건너뛰고 실제 호출자 찾기
+            if (!methodName.startsWith("log") &&
+                !methodName.contains("\$default") &&
+                !fileName.contains("Log")
+            ) {
+                val cleanFileName =
+                    fileName
+                        .replace(".java", "")
+                        .replace(".kt", "")
+
+                return "[$cleanFileName::$methodName (${element.fileName}:${element.lineNumber})] $message"
+            }
+        }
+
+        // 찾지 못하면 기본 인덱스 사용
+        if (stackTrace.size > STACK_TRACE_INDEX) {
+            val element = stackTrace[STACK_TRACE_INDEX]
+            val fileName =
+                element.fileName
+                    ?.replace(".java", "")
+                    ?.replace(".kt", "")
+                    ?: "Unknown"
+
+            "[$fileName::${element.methodName} (${element.fileName}:${element.lineNumber})] $message"
+        } else {
+            message
+        }
+    } catch (exception: Exception) {
+        // 스택 트레이스 추출 실패 시 원본 메시지 반환
+        message
+    }
+}
+
+/**
+ * 디버그 모드인지 확인합니다
+ */
+private fun isLoggingEnabled(): Boolean = BuildConfig.DEBUG
+
+// Verbose 로그
+fun logv(
+    message: String,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.v(tag, buildLogMessage(message))
+}
+
+// Debug 로그
+fun logd(
+    message: String,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.d(tag, buildLogMessage(message))
+}
+
+// Info 로그
+fun logi(
+    message: String,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.i(tag, buildLogMessage(message))
+}
+
+// Warning 로그
+fun logw(
+    message: String,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.w(tag, buildLogMessage(message))
+}
+
+// Error 로그
+fun loge(
+    message: String,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.e(tag, buildLogMessage(message))
+}
+
+// Error 로그 (이름 포함)
+fun loge(
+    name: String,
+    message: String,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.e(tag, buildLogMessage("$name: $message"))
+}
+
+// Error 로그 (예외 포함)
+fun loge(
+    message: String,
+    throwable: Throwable,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.e(tag, buildLogMessage(message), throwable)
+}
+
+// Error 로그 (이름과 예외 모두 포함)
+fun loge(
+    name: String,
+    message: String,
+    throwable: Throwable,
+    tag: String = TAG,
+) {
+    if (!isLoggingEnabled()) return
+    Log.e(tag, buildLogMessage("$name: $message"), throwable)
+}

--- a/Near/app/src/main/java/com/alarmy/near/utils/logger/NearLog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/utils/logger/NearLog.kt
@@ -4,52 +4,38 @@ import android.util.Log
 import com.alarmy.near.BuildConfig
 
 private const val TAG = "Near"
-private const val STACK_TRACE_INDEX = 5
+private const val LOGGER_FILE_NAME = "NearLog.kt"
 
-/**
- * 호출자 정보를 포함한 로그 메시지를 생성합니다
- * 스택 트레이스 추출에 실패하면 원본 메시지를 반환합니다
- */
 private fun buildLogMessage(message: String): String {
     return try {
         val stackTrace = Thread.currentThread().stackTrace
 
-        // 실제 호출자를 찾기 위해 스택을 순회
-        for (i in 4 until stackTrace.size) {
-            val element = stackTrace[i]
-            val fileName = element.fileName ?: continue
-            val methodName = element.methodName ?: continue
-
-            // 로그 관련 메서드들을 건너뛰고 실제 호출자 찾기
-            if (!methodName.startsWith("log") &&
-                !methodName.contains("\$default") &&
-                !fileName.contains("Log")
-            ) {
-                val cleanFileName =
-                    fileName
-                        .replace(".java", "")
-                        .replace(".kt", "")
-
-                return "[$cleanFileName::$methodName (${element.fileName}:${element.lineNumber})] $message"
+        // 스택 트레이스를 순회하며 로거 파일이 아닌 첫 번째 호출자를 찾습니다
+        // 인덱스 0: Thread.getStackTrace()
+        // 인덱스 1: 현재 함수 (buildLogMessage)
+        // 인덱스 2~: 로그 함수들 (logd, loge 등)
+        // 그 이후: 실제 호출자
+        val callerElement =
+            stackTrace.drop(2).firstOrNull { element ->
+                element.fileName != LOGGER_FILE_NAME
             }
+
+        if (callerElement == null) {
+            return "[CallerNotFound] $message"
         }
 
-        // 찾지 못하면 기본 인덱스 사용
-        if (stackTrace.size > STACK_TRACE_INDEX) {
-            val element = stackTrace[STACK_TRACE_INDEX]
-            val fileName =
-                element.fileName
-                    ?.replace(".java", "")
-                    ?.replace(".kt", "")
-                    ?: "Unknown"
+        val fileName =
+            callerElement.fileName
+                ?.substringBeforeLast('.')
+                ?: "Unknown"
 
-            "[$fileName::${element.methodName} (${element.fileName}:${element.lineNumber})] $message"
-        } else {
-            message
-        }
+        val methodName = callerElement.methodName ?: "unknownMethod"
+        val lineNumber = callerElement.lineNumber
+        val originalFileName = callerElement.fileName ?: "Unknown"
+
+        "[$fileName::$methodName ($originalFileName:$lineNumber)] $message"
     } catch (exception: Exception) {
-        // 스택 트레이스 추출 실패 시 원본 메시지 반환
-        message
+        "[LogError:${exception.javaClass.simpleName}] $message"
     }
 }
 


### PR DESCRIPTION
## 작업 내용
- 로그 확장을 통해 로깅 시스템 개선
- 안드로이드 기본 Log를 사용하면 릴리즈모드에서의 로그 관리가 어려워지는 것을 개선
- 디버그/릴리즈 환경별로 로그 레벨을 다르게 관리
- 로그 포맷팅, 태그 관리 필요
- 전역에서 일관된 로깅 시스템을 구축

## 확인 방법
utils/NearLog.kt에 로그 확삼 함수 구현하였습니다.

## 참고 사항

### 구현부
```kotlin
// Debug 로그
fun logd(
    message: String,
    tag: String = TAG,
) {
    if (!isLoggingEnabled()) return
    Log.d(tag, buildLogMessage(message))
}
```
디버그모드에서만 로그가 출력되도록 구현하였습니다

일반 Log.d()와는 다르게 tag를  message 파라미터 뒤에 구현하였습니다.
tag의 생략을 고려하여 위와 같이 구현하였습니다.


### 사용법
```kotlin
@HiltAndroidApp
class NearApplication : Application() {
    override fun onCreate() {
        super.onCreate()
        logd("onCreate: ", "NearApplication")    // 1번째 - 커스텀 태그
        logd("onCreate: ")          // 2번째 - 기본 태그 "Near"
    }
}
```

### 결과
```
Near: [NearApplication::onCreate (NearApplication.kt:7)] onCreate: 
```

## 관련 이슈
- close #24 
