### PR TITLE
[FEAT] 로그인 성공 후 개인정보 동의

### DIFF
--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -38,8 +38,12 @@ internal fun LoginRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.loginSuccessEvent.collect {
-            onNavigateToHome()
+        viewModel.event.collect { event ->
+            when(event) {
+                is LoginEvent.NavigateToHome -> onNavigateToHome
+                is LoginEvent.ShowError -> TODO()
+                is LoginEvent.ShowPrivacyBottomSheet -> TODO()
+            }
         }
     }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -30,6 +30,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.alarmy.near.R
 import com.alarmy.near.model.ProviderType
+import com.alarmy.near.presentation.feature.login.model.TermType
 import com.alarmy.near.presentation.ui.theme.NearTheme
 
 @Composable

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -36,13 +38,22 @@ internal fun LoginRoute(
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showPrivacyBottomSheet by remember { mutableStateOf(false) }
 
+    // 통합된 이벤트 처리
     LaunchedEffect(Unit) {
         viewModel.event.collect { event ->
-            when(event) {
-                is LoginEvent.NavigateToHome -> onNavigateToHome
+            when (event) {
+                is LoginEvent.ShowPrivacyBottomSheet -> {
+                    showPrivacyBottomSheet = true
+                }
+
+                is LoginEvent.NavigateToHome -> {
+                    showPrivacyBottomSheet = false
+                    onNavigateToHome()
+                }
+
                 is LoginEvent.ShowError -> TODO()
-                is LoginEvent.ShowPrivacyBottomSheet -> TODO()
             }
         }
     }
@@ -51,6 +62,17 @@ internal fun LoginRoute(
         uiState = uiState,
         onLoginClick = { providerType ->
             viewModel.performLogin(providerType)
+        },
+    )
+
+    // 개인정보 동의 바텀시트
+    PrivacyConsentBottomSheet(
+        isVisible = showPrivacyBottomSheet,
+        onDismiss = {
+            showPrivacyBottomSheet = false
+        },
+        onConsentComplete = {
+            viewModel.onPrivacyConsentComplete()
         },
     )
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -38,6 +38,7 @@ import com.alarmy.near.presentation.ui.theme.NearTheme
 internal fun LoginRoute(
     onNavigateToHome: () -> Unit,
     onNavigateToWebView: (title: String, url: String) -> Unit,
+    onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -45,11 +46,12 @@ internal fun LoginRoute(
     val lifecycleOwner = LocalLifecycleOwner.current
 
     // 약관 제목을 미리 가져옴
-    val termsTitles = mapOf(
-        TermType.SERVICE_TERMS to stringResource(TermType.SERVICE_TERMS.titleRes),
-        TermType.PRIVACY_COLLECTION to stringResource(TermType.PRIVACY_COLLECTION.titleRes),
-        TermType.PRIVACY_POLICY to stringResource(TermType.PRIVACY_POLICY.titleRes),
-    )
+    val termsTitles =
+        mapOf(
+            TermType.SERVICE_TERMS to stringResource(TermType.SERVICE_TERMS.titleRes),
+            TermType.PRIVACY_COLLECTION to stringResource(TermType.PRIVACY_COLLECTION.titleRes),
+            TermType.PRIVACY_POLICY to stringResource(TermType.PRIVACY_POLICY.titleRes),
+        )
 
     // 웹뷰에서 돌아올 때 바텀시트 복원
     LaunchedEffect(lifecycleOwner) {
@@ -70,7 +72,9 @@ internal fun LoginRoute(
                     onNavigateToWebView(title, event.termType.url)
                 }
 
-                is LoginEvent.ShowError -> TODO()
+                is LoginEvent.ShowError -> {
+                    onShowErrorSnackBar(event.throwable)
+                }
             }
         }
     }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -95,6 +95,11 @@ internal fun LoginRoute(
         onConsentComplete = {
             viewModel.onPrivacyConsentComplete()
         },
+        onTermsClick = { termType ->
+            viewModel.markNavigatedToWebView()
+            val title = termsTitles[termType] ?: ""
+            onNavigateToWebView(title, termType.url)
+        },
         viewModel = viewModel,
     )
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -38,6 +38,7 @@ internal fun LoginRoute(
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val termsAgreementState by viewModel.termsAgreementState.collectAsStateWithLifecycle()
     var showPrivacyBottomSheet by remember { mutableStateOf(false) }
 
     // 통합된 이벤트 처리
@@ -51,6 +52,10 @@ internal fun LoginRoute(
                 is LoginEvent.NavigateToHome -> {
                     showPrivacyBottomSheet = false
                     onNavigateToHome()
+                }
+
+                is LoginEvent.ShowTermsDetail -> {
+                    // TODO: 웹뷰로 약관 상세 보기 이동
                 }
 
                 is LoginEvent.ShowError -> TODO()
@@ -73,6 +78,16 @@ internal fun LoginRoute(
         },
         onConsentComplete = {
             viewModel.onPrivacyConsentComplete()
+        },
+        termsAgreementState = termsAgreementState,
+        onToggleAllTerms = {
+            viewModel.toggleAllTermsAgreement()
+        },
+        onToggleIndividualTerms = { termType ->
+            viewModel.toggleIndividualTermsAgreement(termType)
+        },
+        onShowTermsDetail = { termType ->
+            viewModel.showTermsDetail(termType)
         },
     )
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -17,9 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -27,7 +25,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.alarmy.near.R
 import com.alarmy.near.model.ProviderType
 import com.alarmy.near.presentation.feature.login.model.TermType
@@ -40,8 +41,8 @@ internal fun LoginRoute(
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val termsAgreementState by viewModel.termsAgreementState.collectAsStateWithLifecycle()
-    var showPrivacyBottomSheet by remember { mutableStateOf(false) }
+    val showPrivacyBottomSheet by viewModel.showPrivacyBottomSheet.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     // 약관 제목을 미리 가져옴
     val termsTitles = mapOf(
@@ -50,16 +51,17 @@ internal fun LoginRoute(
         TermType.PRIVACY_POLICY to stringResource(TermType.PRIVACY_POLICY.titleRes),
     )
 
-    // 통합된 이벤트 처리
+    // 웹뷰에서 돌아올 때 바텀시트 복원
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            viewModel.restoreBottomSheetIfNeeded()
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.event.collect { event ->
             when (event) {
-                is LoginEvent.ShowPrivacyBottomSheet -> {
-                    showPrivacyBottomSheet = true
-                }
-
                 is LoginEvent.NavigateToHome -> {
-                    showPrivacyBottomSheet = false
                     onNavigateToHome()
                 }
 
@@ -84,21 +86,12 @@ internal fun LoginRoute(
     PrivacyConsentBottomSheet(
         isVisible = showPrivacyBottomSheet,
         onDismiss = {
-            showPrivacyBottomSheet = false
+            viewModel.dismissPrivacyBottomSheet()
         },
         onConsentComplete = {
             viewModel.onPrivacyConsentComplete()
         },
-        termsAgreementState = termsAgreementState,
-        onToggleAllTerms = {
-            viewModel.toggleAllTermsAgreement()
-        },
-        onToggleIndividualTerms = { termType ->
-            viewModel.toggleIndividualTermsAgreement(termType)
-        },
-        onShowTermsDetail = { termType ->
-            viewModel.showTermsDetail(termType)
-        },
+        viewModel = viewModel,
     )
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -35,11 +35,19 @@ import com.alarmy.near.presentation.ui.theme.NearTheme
 @Composable
 internal fun LoginRoute(
     onNavigateToHome: () -> Unit,
+    onNavigateToWebView: (title: String, url: String) -> Unit,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val termsAgreementState by viewModel.termsAgreementState.collectAsStateWithLifecycle()
     var showPrivacyBottomSheet by remember { mutableStateOf(false) }
+
+    // 약관 제목을 미리 가져옴
+    val termsTitles = mapOf(
+        TermType.SERVICE_TERMS to stringResource(TermType.SERVICE_TERMS.titleRes),
+        TermType.PRIVACY_COLLECTION to stringResource(TermType.PRIVACY_COLLECTION.titleRes),
+        TermType.PRIVACY_POLICY to stringResource(TermType.PRIVACY_POLICY.titleRes),
+    )
 
     // 통합된 이벤트 처리
     LaunchedEffect(Unit) {
@@ -55,7 +63,8 @@ internal fun LoginRoute(
                 }
 
                 is LoginEvent.ShowTermsDetail -> {
-                    // TODO: 웹뷰로 약관 상세 보기 이동
+                    val title = termsTitles[event.termType] ?: ""
+                    onNavigateToWebView(title, event.termType.url)
                 }
 
                 is LoginEvent.ShowError -> TODO()

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginScreen.kt
@@ -43,6 +43,7 @@ internal fun LoginRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val showPrivacyBottomSheet by viewModel.showPrivacyBottomSheet.collectAsStateWithLifecycle()
+    val termsAgreementState by viewModel.termsAgreementState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
 
     // 약관 제목을 미리 가져옴
@@ -89,18 +90,24 @@ internal fun LoginRoute(
     // 개인정보 동의 바텀시트
     PrivacyConsentBottomSheet(
         isVisible = showPrivacyBottomSheet,
+        termsAgreementState = termsAgreementState,
         onDismiss = {
             viewModel.dismissPrivacyBottomSheet()
         },
         onConsentComplete = {
             viewModel.onPrivacyConsentComplete()
         },
+        onToggleAllTerms = {
+            viewModel.toggleAllTermsAgreement()
+        },
+        onToggleIndividualTerms = { termType ->
+            viewModel.toggleIndividualTermsAgreement(termType)
+        },
         onTermsClick = { termType ->
             viewModel.markNavigatedToWebView()
             val title = termsTitles[termType] ?: ""
             onNavigateToWebView(title, termType.url)
         },
-        viewModel = viewModel,
     )
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -7,7 +7,6 @@ import com.alarmy.near.model.ProviderType
 import com.alarmy.near.presentation.feature.login.model.TermType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -141,18 +140,10 @@ class LoginViewModel
         }
 
         /**
-         * 약관 상세 보기 (웹뷰로 이동)
+         * 약관 상세 보기 시 웹뷰로 이동했음을 표시
          */
-        fun showTermsDetail(termType: TermType) {
-            viewModelScope.launch {
-                _loginState.value =
-                    _loginState.value.copy(
-                        showPrivacyBottomSheet = false,
-                        hasNavigatedToWebView = true,
-                    )
-                delay(500)
-                _event.send(LoginEvent.ShowTermsDetail(termType))
-            }
+        fun markNavigatedToWebView() {
+            _loginState.value = _loginState.value.copy(hasNavigatedToWebView = true)
         }
 
         /**

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -7,10 +7,14 @@ import com.alarmy.near.model.ProviderType
 import com.alarmy.near.presentation.feature.login.model.TermType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -28,9 +32,27 @@ class LoginViewModel
         private val _event = Channel<LoginEvent>()
         val event = _event.receiveAsFlow()
 
-        // 약관 동의 상태 관리
-        private val _termsAgreementState = MutableStateFlow(TermsAgreementState())
-        val termsAgreementState: StateFlow<TermsAgreementState> = _termsAgreementState.asStateFlow()
+        // 로그인 화면 상태 관리
+        private val _loginState = MutableStateFlow(LoginState())
+        val loginState: StateFlow<LoginState> = _loginState.asStateFlow()
+
+        // 개별 상태들을 편의를 위해 노출
+        val termsAgreementState: StateFlow<TermsAgreementState> =
+            _loginState
+                .map { it.termsAgreementState }
+                .stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(),
+                    TermsAgreementState(),
+                )
+        val showPrivacyBottomSheet: StateFlow<Boolean> =
+            _loginState
+                .map { it.showPrivacyBottomSheet }
+                .stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(),
+                    false,
+                )
 
         /**
          * 소셜 로그인 수행
@@ -42,7 +64,7 @@ class LoginViewModel
                     .performSocialLogin(providerType)
                     .onSuccess {
                         updateLoadingState(isLoading = false)
-                        _event.send(LoginEvent.ShowPrivacyBottomSheet)
+                        _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = true)
                     }.onFailure { exception ->
                         updateLoadingState(isLoading = false)
                         _event.send(LoginEvent.ShowError(exception))
@@ -55,8 +77,16 @@ class LoginViewModel
          */
         fun onPrivacyConsentComplete() {
             viewModelScope.launch {
+                _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
                 _event.send(LoginEvent.NavigateToHome)
             }
+        }
+
+        /**
+         * 프라이버시 바텀시트 닫기
+         */
+        fun dismissPrivacyBottomSheet() {
+            _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
         }
 
         /**
@@ -70,37 +100,44 @@ class LoginViewModel
          * 약관 전체 동의 토글
          */
         fun toggleAllTermsAgreement() {
-            val currentState = _termsAgreementState.value
-            val newAgreedState = !currentState.isAllAgreed
+            val currentTermsState = _loginState.value.termsAgreementState
+            val newAgreedState = !currentTermsState.isAllAgreed
 
-            _termsAgreementState.value =
-                currentState.copy(
+            val updatedTermsState =
+                currentTermsState.copy(
                     isAllAgreed = newAgreedState,
                     isServiceTermsAgreed = newAgreedState,
                     isPrivacyCollectionAgreed = newAgreedState,
                     isPrivacyPolicyAgreed = newAgreedState,
                 )
+
+            _loginState.value = _loginState.value.copy(termsAgreementState = updatedTermsState)
         }
 
         /**
          * 개별 약관 동의 토글
          */
         fun toggleIndividualTermsAgreement(termType: TermType) {
-            val currentState = _termsAgreementState.value
-            val newState =
+            val currentTermsState = _loginState.value.termsAgreementState
+            val newTermsState =
                 when (termType) {
-                    TermType.SERVICE_TERMS -> currentState.copy(isServiceTermsAgreed = !currentState.isServiceTermsAgreed)
-                    TermType.PRIVACY_COLLECTION -> currentState.copy(isPrivacyCollectionAgreed = !currentState.isPrivacyCollectionAgreed)
-                    TermType.PRIVACY_POLICY -> currentState.copy(isPrivacyPolicyAgreed = !currentState.isPrivacyPolicyAgreed)
+                    TermType.SERVICE_TERMS -> currentTermsState.copy(isServiceTermsAgreed = !currentTermsState.isServiceTermsAgreed)
+                    TermType.PRIVACY_COLLECTION ->
+                        currentTermsState.copy(
+                            isPrivacyCollectionAgreed = !currentTermsState.isPrivacyCollectionAgreed,
+                        )
+
+                    TermType.PRIVACY_POLICY -> currentTermsState.copy(isPrivacyPolicyAgreed = !currentTermsState.isPrivacyPolicyAgreed)
                 }
 
             // 모든 개별 약관이 동의되었는지 확인하여 전체 동의 상태 업데이트
             val isAllIndividualAgreed =
-                newState.isServiceTermsAgreed &&
-                    newState.isPrivacyCollectionAgreed &&
-                    newState.isPrivacyPolicyAgreed
+                newTermsState.isServiceTermsAgreed &&
+                    newTermsState.isPrivacyCollectionAgreed &&
+                    newTermsState.isPrivacyPolicyAgreed
 
-            _termsAgreementState.value = newState.copy(isAllAgreed = isAllIndividualAgreed)
+            val updatedTermsState = newTermsState.copy(isAllAgreed = isAllIndividualAgreed)
+            _loginState.value = _loginState.value.copy(termsAgreementState = updatedTermsState)
         }
 
         /**
@@ -108,10 +145,39 @@ class LoginViewModel
          */
         fun showTermsDetail(termType: TermType) {
             viewModelScope.launch {
+                _loginState.value =
+                    _loginState.value.copy(
+                        showPrivacyBottomSheet = false,
+                        hasNavigatedToWebView = true,
+                    )
+                delay(500)
                 _event.send(LoginEvent.ShowTermsDetail(termType))
             }
         }
+
+        /**
+         * 웹뷰에서 돌아온 후 바텀시트 복원
+         */
+        fun restoreBottomSheetIfNeeded() {
+            val currentState = _loginState.value
+            if (currentState.hasNavigatedToWebView && !currentState.showPrivacyBottomSheet) {
+                _loginState.value =
+                    currentState.copy(
+                        showPrivacyBottomSheet = true,
+                        hasNavigatedToWebView = false,
+                    )
+            }
+        }
     }
+
+/**
+ * 로그인 화면 통합 상태
+ */
+data class LoginState(
+    val termsAgreementState: TermsAgreementState = TermsAgreementState(),
+    val hasNavigatedToWebView: Boolean = false,
+    val showPrivacyBottomSheet: Boolean = false,
+)
 
 /**
  * 로그인 화면 UI 상태
@@ -142,8 +208,6 @@ data class TermsAgreementState(
 *
 * */
 sealed class LoginEvent {
-    object ShowPrivacyBottomSheet : LoginEvent()
-
     object NavigateToHome : LoginEvent()
 
     data class ShowTermsDetail(

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -37,16 +37,24 @@ class LoginViewModel
         fun performLogin(providerType: ProviderType) {
             viewModelScope.launch {
                 updateLoadingState(isLoading = true)
-
                 authRepository
                     .performSocialLogin(providerType)
                     .onSuccess {
                         updateLoadingState(isLoading = false)
-                        _event.send(LoginEvent.NavigateToHome)
+                        _event.send(LoginEvent.ShowPrivacyBottomSheet)
                     }.onFailure { exception ->
                         updateLoadingState(isLoading = false)
                         _event.send(LoginEvent.ShowError(exception))
                     }
+            }
+        }
+
+        /**
+         * 개인정보 동의 완료 처리
+         */
+        fun onPrivacyConsentComplete() {
+            viewModelScope.launch {
+                _event.send(LoginEvent.NavigateToHome)
             }
         }
 
@@ -63,13 +71,14 @@ class LoginViewModel
         fun toggleAllTermsAgreement() {
             val currentState = _termsAgreementState.value
             val newAgreedState = !currentState.isAllAgreed
-            
-            _termsAgreementState.value = currentState.copy(
-                isAllAgreed = newAgreedState,
-                isServiceTermsAgreed = newAgreedState,
-                isPrivacyCollectionAgreed = newAgreedState,
-                isPrivacyPolicyAgreed = newAgreedState
-            )
+
+            _termsAgreementState.value =
+                currentState.copy(
+                    isAllAgreed = newAgreedState,
+                    isServiceTermsAgreed = newAgreedState,
+                    isPrivacyCollectionAgreed = newAgreedState,
+                    isPrivacyPolicyAgreed = newAgreedState,
+                )
         }
 
         /**
@@ -77,17 +86,19 @@ class LoginViewModel
          */
         fun toggleIndividualTermsAgreement(termType: TermType) {
             val currentState = _termsAgreementState.value
-            val newState = when (termType) {
-                TermType.SERVICE_TERMS -> currentState.copy(isServiceTermsAgreed = !currentState.isServiceTermsAgreed)
-                TermType.PRIVACY_COLLECTION -> currentState.copy(isPrivacyCollectionAgreed = !currentState.isPrivacyCollectionAgreed)
-                TermType.PRIVACY_POLICY -> currentState.copy(isPrivacyPolicyAgreed = !currentState.isPrivacyPolicyAgreed)
-            }
-            
+            val newState =
+                when (termType) {
+                    TermType.SERVICE_TERMS -> currentState.copy(isServiceTermsAgreed = !currentState.isServiceTermsAgreed)
+                    TermType.PRIVACY_COLLECTION -> currentState.copy(isPrivacyCollectionAgreed = !currentState.isPrivacyCollectionAgreed)
+                    TermType.PRIVACY_POLICY -> currentState.copy(isPrivacyPolicyAgreed = !currentState.isPrivacyPolicyAgreed)
+                }
+
             // 모든 개별 약관이 동의되었는지 확인하여 전체 동의 상태 업데이트
-            val isAllIndividualAgreed = newState.isServiceTermsAgreed && 
-                                      newState.isPrivacyCollectionAgreed && 
-                                      newState.isPrivacyPolicyAgreed
-            
+            val isAllIndividualAgreed =
+                newState.isServiceTermsAgreed &&
+                    newState.isPrivacyCollectionAgreed &&
+                    newState.isPrivacyPolicyAgreed
+
             _termsAgreementState.value = newState.copy(isAllAgreed = isAllIndividualAgreed)
         }
 
@@ -131,7 +142,7 @@ data class TermsAgreementState(
 enum class TermType {
     SERVICE_TERMS,
     PRIVACY_COLLECTION,
-    PRIVACY_POLICY
+    PRIVACY_POLICY,
 }
 
 /*

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -27,6 +27,10 @@ class LoginViewModel
         private val _event = Channel<LoginEvent>()
         val event = _event.receiveAsFlow()
 
+        // 약관 동의 상태 관리
+        private val _termsAgreementState = MutableStateFlow(TermsAgreementState())
+        val termsAgreementState: StateFlow<TermsAgreementState> = _termsAgreementState.asStateFlow()
+
         /**
          * 소셜 로그인 수행
          */
@@ -52,6 +56,49 @@ class LoginViewModel
         private fun updateLoadingState(isLoading: Boolean) {
             _uiState.value = _uiState.value.copy(isLoading = isLoading)
         }
+
+        /**
+         * 약관 전체 동의 토글
+         */
+        fun toggleAllTermsAgreement() {
+            val currentState = _termsAgreementState.value
+            val newAgreedState = !currentState.isAllAgreed
+            
+            _termsAgreementState.value = currentState.copy(
+                isAllAgreed = newAgreedState,
+                isServiceTermsAgreed = newAgreedState,
+                isPrivacyCollectionAgreed = newAgreedState,
+                isPrivacyPolicyAgreed = newAgreedState
+            )
+        }
+
+        /**
+         * 개별 약관 동의 토글
+         */
+        fun toggleIndividualTermsAgreement(termType: TermType) {
+            val currentState = _termsAgreementState.value
+            val newState = when (termType) {
+                TermType.SERVICE_TERMS -> currentState.copy(isServiceTermsAgreed = !currentState.isServiceTermsAgreed)
+                TermType.PRIVACY_COLLECTION -> currentState.copy(isPrivacyCollectionAgreed = !currentState.isPrivacyCollectionAgreed)
+                TermType.PRIVACY_POLICY -> currentState.copy(isPrivacyPolicyAgreed = !currentState.isPrivacyPolicyAgreed)
+            }
+            
+            // 모든 개별 약관이 동의되었는지 확인하여 전체 동의 상태 업데이트
+            val isAllIndividualAgreed = newState.isServiceTermsAgreed && 
+                                      newState.isPrivacyCollectionAgreed && 
+                                      newState.isPrivacyPolicyAgreed
+            
+            _termsAgreementState.value = newState.copy(isAllAgreed = isAllIndividualAgreed)
+        }
+
+        /**
+         * 약관 상세 보기 (웹뷰로 이동)
+         */
+        fun showTermsDetail(termType: TermType) {
+            viewModelScope.launch {
+                _event.send(LoginEvent.ShowTermsDetail(termType))
+            }
+        }
     }
 
 /**
@@ -62,6 +109,31 @@ data class LoginUiState(
     val hasError: Boolean = false,
 )
 
+/**
+ * 약관 동의 상태
+ */
+data class TermsAgreementState(
+    val isAllAgreed: Boolean = false,
+    val isServiceTermsAgreed: Boolean = false,
+    val isPrivacyCollectionAgreed: Boolean = false,
+    val isPrivacyPolicyAgreed: Boolean = false,
+) {
+    /**
+     * 모든 필수 약관에 동의했는지 확인
+     */
+    val isAllRequiredTermsAgreed: Boolean
+        get() = isServiceTermsAgreed && isPrivacyCollectionAgreed && isPrivacyPolicyAgreed
+}
+
+/**
+ * 약관 타입
+ */
+enum class TermType {
+    SERVICE_TERMS,
+    PRIVACY_COLLECTION,
+    PRIVACY_POLICY
+}
+
 /*
 * 로그인 화면 이벤트 관리
 *
@@ -70,6 +142,10 @@ sealed class LoginEvent {
     object ShowPrivacyBottomSheet : LoginEvent()
 
     object NavigateToHome : LoginEvent()
+
+    data class ShowTermsDetail(
+        val termType: TermType,
+    ) : LoginEvent()
 
     data class ShowError(
         val throwable: Throwable?,

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -1,12 +1,10 @@
 package com.alarmy.near.presentation.feature.login
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.alarmy.near.BuildConfig
-import com.alarmy.near.R
 import com.alarmy.near.data.repository.AuthRepository
 import com.alarmy.near.model.ProviderType
+import com.alarmy.near.presentation.feature.login.model.TermType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -137,27 +135,6 @@ data class TermsAgreementState(
      */
     val isAllRequiredTermsAgreed: Boolean
         get() = isServiceTermsAgreed && isPrivacyCollectionAgreed && isPrivacyPolicyAgreed
-}
-
-/**
- * 약관 및 정책 타입
- */
-enum class TermType(
-    @StringRes val titleRes: Int,
-    val url: String,
-) {
-    SERVICE_TERMS(
-        titleRes = R.string.terms_service_agreed,
-        url = BuildConfig.SERVICE_AGREED_TERMS_URL,
-    ),
-    PRIVACY_COLLECTION(
-        titleRes = R.string.terms_personal_info,
-        url = BuildConfig.PERSONAL_INFO_TERMS_URL,
-    ),
-    PRIVACY_POLICY(
-        titleRes = R.string.terms_privacy_policy,
-        url = BuildConfig.PRIVACY_POLICY_TERMS_URL,
-    ),
 }
 
 /*

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -1,7 +1,10 @@
 package com.alarmy.near.presentation.feature.login
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.alarmy.near.BuildConfig
+import com.alarmy.near.R
 import com.alarmy.near.data.repository.AuthRepository
 import com.alarmy.near.model.ProviderType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -137,12 +140,24 @@ data class TermsAgreementState(
 }
 
 /**
- * 약관 타입
+ * 약관 및 정책 타입
  */
-enum class TermType {
-    SERVICE_TERMS,
-    PRIVACY_COLLECTION,
-    PRIVACY_POLICY,
+enum class TermType(
+    @StringRes val titleRes: Int,
+    val url: String,
+) {
+    SERVICE_TERMS(
+        titleRes = R.string.terms_service_agreed,
+        url = BuildConfig.SERVICE_AGREED_TERMS_URL,
+    ),
+    PRIVACY_COLLECTION(
+        titleRes = R.string.terms_personal_info,
+        url = BuildConfig.PERSONAL_INFO_TERMS_URL,
+    ),
+    PRIVACY_POLICY(
+        titleRes = R.string.terms_privacy_policy,
+        url = BuildConfig.PRIVACY_POLICY_TERMS_URL,
+    ),
 }
 
 /*

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -23,13 +23,9 @@ class LoginViewModel
         private val _uiState = MutableStateFlow(LoginUiState())
         val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
-        // 에러 이벤트 관리
-        private val _errorEvent = Channel<Throwable?>()
-        val errorEvent = _errorEvent.receiveAsFlow()
-
-        // 로그인 성공 이벤트 관리
-        private val _loginSuccessEvent = Channel<Unit>()
-        val loginSuccessEvent = _loginSuccessEvent.receiveAsFlow()
+        // 이벤트 관리
+        private val _event = Channel<LoginEvent>()
+        val event = _event.receiveAsFlow()
 
         /**
          * 소셜 로그인 수행
@@ -38,14 +34,14 @@ class LoginViewModel
             viewModelScope.launch {
                 updateLoadingState(isLoading = true)
 
-                authRepository.performSocialLogin(providerType)
+                authRepository
+                    .performSocialLogin(providerType)
                     .onSuccess {
                         updateLoadingState(isLoading = false)
-                        _loginSuccessEvent.send(Unit)
-                    }
-                    .onFailure { exception ->
+                        _event.send(LoginEvent.NavigateToHome)
+                    }.onFailure { exception ->
                         updateLoadingState(isLoading = false)
-                        _errorEvent.send(exception)
+                        _event.send(LoginEvent.ShowError(exception))
                     }
             }
         }
@@ -65,3 +61,17 @@ data class LoginUiState(
     val isLoading: Boolean = false,
     val hasError: Boolean = false,
 )
+
+/*
+* 로그인 화면 이벤트 관리
+*
+* */
+sealed class LoginEvent {
+    object ShowPrivacyBottomSheet : LoginEvent()
+
+    object NavigateToHome : LoginEvent()
+
+    data class ShowError(
+        val throwable: Throwable?,
+    ) : LoginEvent()
+}

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.alarmy.near.R
 import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
@@ -64,68 +65,84 @@ fun PrivacyConsentBottomSheet(
             containerColor = NearTheme.colors.WHITE_FFFFFF,
             contentColor = NearTheme.colors.BLACK_1A1A1A,
         ) {
-            Column(
-                modifier = Modifier.padding(horizontal = 20.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                // 바텀시트 제목
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(R.string.privacy_consent_title),
-                    style = NearTheme.typography.B1_16_BOLD,
-                    textAlign = TextAlign.Start,
-                )
-
-                Spacer(modifier = Modifier.size(24.dp))
-
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .border(
-                                width = 1.dp,
-                                color = NearTheme.colors.GRAY03_EBEBEB,
-                                shape = RoundedCornerShape(12.dp),
-                            )
-                            .onNoRippleClick { onToggleAllTerms() }
-                            .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    // 전체 체크
-                    TermsAllCheckAgreementSection(
-                        termsAgreementState = termsAgreementState,
-                        onToggleAllTerms = onToggleAllTerms,
-                    )
-                }
-
-                Spacer(modifier = Modifier.size(16.dp))
-
-                // 개별 약관 동의
-                TermsAgreementSection(
-                    termsAgreementState = termsAgreementState,
-                    onToggleIndividualTerms = onToggleIndividualTerms,
-                    onShowTermsDetail = { termType ->
-                        dismissAndNavigateToTerms(termType)
-                    },
-                )
-
-                Spacer(modifier = Modifier.size(32.dp))
-
-                NearBasicButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentPadding = PaddingValues(vertical = 16.dp),
-                    onClick = onConsentComplete,
-                    enabled = termsAgreementState.isAllRequiredTermsAgreed,
-                ) {
-                    Text(
-                        text = stringResource(R.string.privacy_consent_signup_button),
-                        style = NearTheme.typography.B1_16_BOLD,
-                    )
-                }
-
-                Spacer(modifier = Modifier.size(24.dp))
-            }
+            PrivacyConsentBottomSheetContent(
+                termsAgreementState = termsAgreementState,
+                onToggleAllTerms = onToggleAllTerms,
+                onToggleIndividualTerms = onToggleIndividualTerms,
+                onConsentComplete = onConsentComplete,
+                onShowTermsDetail = { termType ->
+                    dismissAndNavigateToTerms(termType)
+                },
+            )
         }
+    }
+}
+
+@Composable
+private fun PrivacyConsentBottomSheetContent(
+    termsAgreementState: TermsAgreementState,
+    onToggleAllTerms: () -> Unit,
+    onToggleIndividualTerms: (TermType) -> Unit,
+    onConsentComplete: () -> Unit,
+    onShowTermsDetail: (TermType) -> Unit,
+) {
+    Column(
+        modifier = Modifier.padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // 바텀시트 제목
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.privacy_consent_title),
+            style = NearTheme.typography.B1_16_BOLD,
+            textAlign = TextAlign.Start,
+        )
+
+        Spacer(modifier = Modifier.size(24.dp))
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 1.dp,
+                        color = NearTheme.colors.GRAY03_EBEBEB,
+                        shape = RoundedCornerShape(12.dp),
+                    ).onNoRippleClick { onToggleAllTerms() }
+                    .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // 전체 체크
+            TermsAllCheckAgreementSection(
+                termsAgreementState = termsAgreementState,
+                onToggleAllTerms = onToggleAllTerms,
+            )
+        }
+
+        Spacer(modifier = Modifier.size(16.dp))
+
+        // 개별 약관 동의
+        TermsAgreementSection(
+            termsAgreementState = termsAgreementState,
+            onToggleIndividualTerms = onToggleIndividualTerms,
+            onShowTermsDetail = onShowTermsDetail,
+        )
+
+        Spacer(modifier = Modifier.size(32.dp))
+
+        NearBasicButton(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(vertical = 16.dp),
+            onClick = onConsentComplete,
+            enabled = termsAgreementState.isAllRequiredTermsAgreed,
+        ) {
+            Text(
+                text = stringResource(R.string.privacy_consent_signup_button),
+                style = NearTheme.typography.B1_16_BOLD,
+            )
+        }
+
+        Spacer(modifier = Modifier.size(24.dp))
     }
 }
 
@@ -173,8 +190,7 @@ private fun TermsAgreementSection(
                     width = 1.dp,
                     color = NearTheme.colors.GRAY03_EBEBEB,
                     shape = RoundedCornerShape(12.dp),
-                )
-                .padding(horizontal = 16.dp, vertical = 4.dp),
+                ).padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         terms.forEachIndexed { index, termType ->
             val isAgreed =
@@ -191,5 +207,45 @@ private fun TermsAgreementSection(
                 showDivider = index < terms.size - 1,
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PrivacyConsentBottomSheetContentPreview() {
+    NearTheme {
+        PrivacyConsentBottomSheetContent(
+            termsAgreementState =
+                TermsAgreementState(
+                    isAllAgreed = false,
+                    isServiceTermsAgreed = true,
+                    isPrivacyCollectionAgreed = false,
+                    isPrivacyPolicyAgreed = true,
+                ),
+            onToggleAllTerms = {},
+            onToggleIndividualTerms = {},
+            onConsentComplete = {},
+            onShowTermsDetail = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PrivacyConsentBottomSheetAllAgreedContentPreview() {
+    NearTheme {
+        PrivacyConsentBottomSheetContent(
+            termsAgreementState =
+                TermsAgreementState(
+                    isAllAgreed = true,
+                    isServiceTermsAgreed = true,
+                    isPrivacyCollectionAgreed = true,
+                    isPrivacyPolicyAgreed = true,
+                ),
+            onToggleAllTerms = {},
+            onToggleIndividualTerms = {},
+            onConsentComplete = {},
+            onShowTermsDetail = {},
+        )
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -139,17 +140,17 @@ private fun TermsAgreementSection(
     val termsList =
         listOf(
             Triple(
-                "[필수] 서비스 이용 약관",
+                "[필수] ${stringResource(TermType.SERVICE_TERMS.titleRes)}",
                 TermType.SERVICE_TERMS,
                 termsAgreementState.isServiceTermsAgreed,
             ),
             Triple(
-                "[필수] 개인정보 수집 및 이용 동의서",
+                "[필수] ${stringResource(TermType.PRIVACY_COLLECTION.titleRes)}",
                 TermType.PRIVACY_COLLECTION,
                 termsAgreementState.isPrivacyCollectionAgreed,
             ),
             Triple(
-                "[필수] 개인정보 처리방침",
+                "[필수] ${stringResource(TermType.PRIVACY_POLICY.titleRes)}",
                 TermType.PRIVACY_POLICY,
                 termsAgreementState.isPrivacyPolicyAgreed,
             ),

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -30,6 +31,7 @@ import com.alarmy.near.presentation.ui.component.button.NearBasicButton
 import com.alarmy.near.presentation.ui.component.checkbox.NearBackgroundCheckbox
 import com.alarmy.near.presentation.ui.extension.onNoRippleClick
 import com.alarmy.near.presentation.ui.theme.NearTheme
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,6 +39,7 @@ fun PrivacyConsentBottomSheet(
     isVisible: Boolean,
     onDismiss: () -> Unit,
     onConsentComplete: () -> Unit,
+    onTermsClick: (TermType) -> Unit = {},
     viewModel: LoginViewModel,
 ) {
     val termsAgreementState by viewModel.termsAgreementState.collectAsStateWithLifecycle()
@@ -45,6 +48,15 @@ fun PrivacyConsentBottomSheet(
             rememberModalBottomSheetState(
                 skipPartiallyExpanded = true,
             )
+        val scope = rememberCoroutineScope()
+
+        // 바텀시트를 닫고 약관 페이지로 이동
+        val dismissAndNavigateToTerms = { termType: TermType ->
+            scope.launch {
+                bottomSheetState.hide()
+                onTermsClick(termType)
+            }
+        }
 
         ModalBottomSheet(
             onDismissRequest = onDismiss,
@@ -96,7 +108,9 @@ fun PrivacyConsentBottomSheet(
                             termType,
                         )
                     },
-                    onShowTermsDetail = { termType -> viewModel.showTermsDetail(termType) },
+                    onShowTermsDetail = { termType ->
+                        dismissAndNavigateToTerms(termType)
+                    },
                 )
 
                 Spacer(modifier = Modifier.size(32.dp))

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.alarmy.near.R
 import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
 import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
 import com.alarmy.near.presentation.feature.login.model.TermType
@@ -59,7 +60,7 @@ fun PrivacyConsentBottomSheet(
                 // 바텀시트 제목
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    text = "서비스 약관 동의",
+                    text = stringResource(R.string.privacy_consent_title),
                     style = NearTheme.typography.B1_16_BOLD,
                     textAlign = TextAlign.Start,
                 )
@@ -103,7 +104,7 @@ fun PrivacyConsentBottomSheet(
                     enabled = termsAgreementState.isAllRequiredTermsAgreed,
                 ) {
                     Text(
-                        text = "가입",
+                        text = stringResource(R.string.privacy_consent_signup_button),
                         style = NearTheme.typography.B1_16_BOLD,
                     )
                 }
@@ -127,7 +128,7 @@ private fun TermsAllCheckAgreementSection(
     Spacer(modifier = Modifier.size(8.dp))
 
     Text(
-        text = "약관 전체 동의",
+        text = stringResource(R.string.privacy_consent_all_agreement),
         style = NearTheme.typography.B2_14_BOLD,
     )
 }
@@ -141,17 +142,17 @@ private fun TermsAgreementSection(
     val termsList =
         listOf(
             Triple(
-                "[필수] ${stringResource(TermType.SERVICE_TERMS.titleRes)}",
+                "${stringResource(R.string.privacy_consent_required_prefix)} ${stringResource(TermType.SERVICE_TERMS.titleRes)}",
                 TermType.SERVICE_TERMS,
                 termsAgreementState.isServiceTermsAgreed,
             ),
             Triple(
-                "[필수] ${stringResource(TermType.PRIVACY_COLLECTION.titleRes)}",
+                "${stringResource(R.string.privacy_consent_required_prefix)} ${stringResource(TermType.PRIVACY_COLLECTION.titleRes)}",
                 TermType.PRIVACY_COLLECTION,
                 termsAgreementState.isPrivacyCollectionAgreed,
             ),
             Triple(
-                "[필수] ${stringResource(TermType.PRIVACY_POLICY.titleRes)}",
+                "${stringResource(R.string.privacy_consent_required_prefix)} ${stringResource(TermType.PRIVACY_POLICY.titleRes)}",
                 TermType.PRIVACY_POLICY,
                 termsAgreementState.isPrivacyPolicyAgreed,
             ),

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -20,9 +19,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
 import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
 import com.alarmy.near.presentation.ui.component.button.NearBasicButton
 import com.alarmy.near.presentation.ui.component.checkbox.NearBackgroundCheckbox
+import com.alarmy.near.presentation.ui.extension.onNoRippleClick
 import com.alarmy.near.presentation.ui.theme.NearTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -31,6 +32,10 @@ fun PrivacyConsentBottomSheet(
     isVisible: Boolean,
     onDismiss: () -> Unit,
     onConsentComplete: () -> Unit,
+    termsAgreementState: TermsAgreementState,
+    onToggleAllTerms: () -> Unit,
+    onToggleIndividualTerms: (TermType) -> Unit,
+    onShowTermsDetail: (TermType) -> Unit,
 ) {
     if (isVisible) {
         val bottomSheetState =
@@ -41,13 +46,7 @@ fun PrivacyConsentBottomSheet(
         ModalBottomSheet(
             onDismissRequest = onDismiss,
             sheetState = bottomSheetState,
-            dragHandle = {
-                BottomSheetDefaults.DragHandle(
-                    color = NearTheme.colors.GRAY03_EBEBEB,
-                    width = 32.dp,
-                    height = 6.dp,
-                )
-            },
+            dragHandle = { NearBottomSheetDragHandle() },
             containerColor = NearTheme.colors.WHITE_FFFFFF,
             contentColor = NearTheme.colors.BLACK_1A1A1A,
         ) {
@@ -73,24 +72,25 @@ fun PrivacyConsentBottomSheet(
                                 width = 1.dp,
                                 color = NearTheme.colors.GRAY03_EBEBEB,
                                 shape = RoundedCornerShape(12.dp),
-                            ).padding(16.dp),
+                            ).onNoRippleClick(onToggleAllTerms)
+                            .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    NearBackgroundCheckbox(
-                        checked = false,
-                    ) { }
-
-                    Spacer(modifier = Modifier.size(8.dp))
-
-                    Text(
-                        text = "약관 전체 동의",
-                        style = NearTheme.typography.B2_14_BOLD,
+                    // 전체 체크
+                    TermsAllCheckAgreementSection(
+                        termsAgreementState = termsAgreementState,
+                        onToggleAllTerms = onToggleAllTerms,
                     )
                 }
 
                 Spacer(modifier = Modifier.size(16.dp))
 
-                TermsAgreementSection()
+                // 개별 약관 동의
+                TermsAgreementSection(
+                    termsAgreementState = termsAgreementState,
+                    onToggleIndividualTerms = onToggleIndividualTerms,
+                    onShowTermsDetail = onShowTermsDetail,
+                )
 
                 Spacer(modifier = Modifier.size(32.dp))
 
@@ -98,6 +98,7 @@ fun PrivacyConsentBottomSheet(
                     modifier = Modifier.fillMaxWidth(),
                     contentPadding = PaddingValues(vertical = 16.dp),
                     onClick = onConsentComplete,
+                    enabled = termsAgreementState.isAllRequiredTermsAgreed,
                 ) {
                     Text(
                         text = "가입",
@@ -112,12 +113,46 @@ fun PrivacyConsentBottomSheet(
 }
 
 @Composable
-private fun TermsAgreementSection() {
+private fun TermsAllCheckAgreementSection(
+    termsAgreementState: TermsAgreementState,
+    onToggleAllTerms: () -> Unit,
+) {
+    NearBackgroundCheckbox(
+        checked = termsAgreementState.isAllAgreed,
+        onCheckedChange = { onToggleAllTerms() },
+    )
+
+    Spacer(modifier = Modifier.size(8.dp))
+
+    Text(
+        text = "약관 전체 동의",
+        style = NearTheme.typography.B2_14_BOLD,
+    )
+}
+
+@Composable
+private fun TermsAgreementSection(
+    termsAgreementState: TermsAgreementState,
+    onToggleIndividualTerms: (TermType) -> Unit,
+    onShowTermsDetail: (TermType) -> Unit,
+) {
     val termsList =
         listOf(
-            "[필수] 서비스 이용 약관",
-            "[필수] 개인정보 수집 및 이용 동의서",
-            "[필수] 개인정보 처리방침",
+            Triple(
+                "[필수] 서비스 이용 약관",
+                TermType.SERVICE_TERMS,
+                termsAgreementState.isServiceTermsAgreed,
+            ),
+            Triple(
+                "[필수] 개인정보 수집 및 이용 동의서",
+                TermType.PRIVACY_COLLECTION,
+                termsAgreementState.isPrivacyCollectionAgreed,
+            ),
+            Triple(
+                "[필수] 개인정보 처리방침",
+                TermType.PRIVACY_POLICY,
+                termsAgreementState.isPrivacyPolicyAgreed,
+            ),
         )
 
     Column(
@@ -130,11 +165,12 @@ private fun TermsAgreementSection() {
                     shape = RoundedCornerShape(12.dp),
                 ).padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
-        termsList.forEachIndexed { index, term ->
+        termsList.forEachIndexed { index, (text, termType, isChecked) ->
             TermsAgreementItem(
-                text = term,
-                isChecked = false,
-                onCheckedChange = { },
+                text = text,
+                isChecked = isChecked,
+                onCheckedChange = { onToggleIndividualTerms(termType) },
+                onclick = { onShowTermsDetail(termType) },
                 showDivider = index < termsList.size - 1,
             )
         }
@@ -149,6 +185,10 @@ fun PrivacyConsentBottomSheetPreview() {
             isVisible = true,
             onDismiss = { },
             onConsentComplete = { },
+            termsAgreementState = TermsAgreementState(),
+            onToggleAllTerms = { },
+            onToggleIndividualTerms = { },
+            onShowTermsDetail = { },
         )
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -22,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.alarmy.near.R
 import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
 import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
@@ -37,12 +35,13 @@ import kotlinx.coroutines.launch
 @Composable
 fun PrivacyConsentBottomSheet(
     isVisible: Boolean,
+    termsAgreementState: TermsAgreementState,
     onDismiss: () -> Unit,
     onConsentComplete: () -> Unit,
+    onToggleAllTerms: () -> Unit,
+    onToggleIndividualTerms: (TermType) -> Unit,
     onTermsClick: (TermType) -> Unit = {},
-    viewModel: LoginViewModel,
 ) {
-    val termsAgreementState by viewModel.termsAgreementState.collectAsStateWithLifecycle()
     if (isVisible) {
         val bottomSheetState =
             rememberModalBottomSheetState(
@@ -87,14 +86,15 @@ fun PrivacyConsentBottomSheet(
                                 width = 1.dp,
                                 color = NearTheme.colors.GRAY03_EBEBEB,
                                 shape = RoundedCornerShape(12.dp),
-                            ).onNoRippleClick { viewModel.toggleAllTermsAgreement() }
+                            )
+                            .onNoRippleClick { onToggleAllTerms() }
                             .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     // 전체 체크
                     TermsAllCheckAgreementSection(
                         termsAgreementState = termsAgreementState,
-                        onToggleAllTerms = { viewModel.toggleAllTermsAgreement() },
+                        onToggleAllTerms = onToggleAllTerms,
                     )
                 }
 
@@ -103,11 +103,7 @@ fun PrivacyConsentBottomSheet(
                 // 개별 약관 동의
                 TermsAgreementSection(
                     termsAgreementState = termsAgreementState,
-                    onToggleIndividualTerms = { termType ->
-                        viewModel.toggleIndividualTermsAgreement(
-                            termType,
-                        )
-                    },
+                    onToggleIndividualTerms = onToggleIndividualTerms,
                     onShowTermsDetail = { termType ->
                         dismissAndNavigateToTerms(termType)
                     },
@@ -177,7 +173,8 @@ private fun TermsAgreementSection(
                     width = 1.dp,
                     color = NearTheme.colors.GRAY03_EBEBEB,
                     shape = RoundedCornerShape(12.dp),
-                ).padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+                .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         terms.forEachIndexed { index, termType ->
             val isAgreed =

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -19,13 +19,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.alarmy.near.R
 import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
 import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
 import com.alarmy.near.presentation.feature.login.model.TermType
+import com.alarmy.near.presentation.feature.login.model.TermsItem
 import com.alarmy.near.presentation.ui.component.button.NearBasicButton
 import com.alarmy.near.presentation.ui.component.checkbox.NearBackgroundCheckbox
 import com.alarmy.near.presentation.ui.extension.onNoRippleClick
@@ -139,24 +139,25 @@ private fun TermsAgreementSection(
     onToggleIndividualTerms: (TermType) -> Unit,
     onShowTermsDetail: (TermType) -> Unit,
 ) {
-    val termsList =
-        listOf(
-            Triple(
-                "${stringResource(R.string.privacy_consent_required_prefix)} ${stringResource(TermType.SERVICE_TERMS.titleRes)}",
-                TermType.SERVICE_TERMS,
-                termsAgreementState.isServiceTermsAgreed,
-            ),
-            Triple(
-                "${stringResource(R.string.privacy_consent_required_prefix)} ${stringResource(TermType.PRIVACY_COLLECTION.titleRes)}",
-                TermType.PRIVACY_COLLECTION,
-                termsAgreementState.isPrivacyCollectionAgreed,
-            ),
-            Triple(
-                "${stringResource(R.string.privacy_consent_required_prefix)} ${stringResource(TermType.PRIVACY_POLICY.titleRes)}",
-                TermType.PRIVACY_POLICY,
-                termsAgreementState.isPrivacyPolicyAgreed,
-            ),
-        )
+    val requiredPrefix = stringResource(R.string.privacy_consent_required_prefix)
+
+    val termsList = listOf(
+        TermsItem(
+            title = "$requiredPrefix ${stringResource(TermType.SERVICE_TERMS.titleRes)}",
+            termType = TermType.SERVICE_TERMS,
+            isAgreed = termsAgreementState.isServiceTermsAgreed,
+        ),
+        TermsItem(
+            title = "$requiredPrefix ${stringResource(TermType.PRIVACY_COLLECTION.titleRes)}",
+            termType = TermType.PRIVACY_COLLECTION,
+            isAgreed = termsAgreementState.isPrivacyCollectionAgreed,
+        ),
+        TermsItem(
+            title = "$requiredPrefix ${stringResource(TermType.PRIVACY_POLICY.titleRes)}",
+            termType = TermType.PRIVACY_POLICY,
+            isAgreed = termsAgreementState.isPrivacyPolicyAgreed,
+        ),
+    )
 
     Column(
         modifier =
@@ -168,16 +169,14 @@ private fun TermsAgreementSection(
                     shape = RoundedCornerShape(12.dp),
                 ).padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
-        termsList.forEachIndexed { index, (text, termType, isChecked) ->
+        termsList.forEachIndexed { index, termsItem ->
             TermsAgreementItem(
-                text = text,
-                isChecked = isChecked,
-                onCheckedChange = { onToggleIndividualTerms(termType) },
-                onclick = { onShowTermsDetail(termType) },
+                text = termsItem.title,
+                isChecked = termsItem.isAgreed,
+                onCheckedChange = { onToggleIndividualTerms(termsItem.termType) },
+                onclick = { onShowTermsDetail(termsItem.termType) },
                 showDivider = index < termsList.size - 1,
             )
         }
     }
 }
-
-// Preview는 ViewModel이 필요하므로 제거하거나 다른 방식으로 구현

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -1,0 +1,154 @@
+package com.alarmy.near.presentation.feature.login
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
+import com.alarmy.near.presentation.ui.component.button.NearBasicButton
+import com.alarmy.near.presentation.ui.component.checkbox.NearBackgroundCheckbox
+import com.alarmy.near.presentation.ui.theme.NearTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PrivacyConsentBottomSheet(
+    isVisible: Boolean,
+    onDismiss: () -> Unit,
+    onConsentComplete: () -> Unit,
+) {
+    if (isVisible) {
+        val bottomSheetState =
+            rememberModalBottomSheetState(
+                skipPartiallyExpanded = true,
+            )
+
+        ModalBottomSheet(
+            onDismissRequest = onDismiss,
+            sheetState = bottomSheetState,
+            dragHandle = {
+                BottomSheetDefaults.DragHandle(
+                    color = NearTheme.colors.GRAY03_EBEBEB,
+                    width = 32.dp,
+                    height = 6.dp,
+                )
+            },
+            containerColor = NearTheme.colors.WHITE_FFFFFF,
+            contentColor = NearTheme.colors.BLACK_1A1A1A,
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // 바텀시트 제목
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "서비스 약관 동의",
+                    style = NearTheme.typography.B1_16_BOLD,
+                    textAlign = TextAlign.Start,
+                )
+
+                Spacer(modifier = Modifier.size(24.dp))
+
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = NearTheme.colors.GRAY03_EBEBEB,
+                                shape = RoundedCornerShape(12.dp),
+                            ).padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    NearBackgroundCheckbox(
+                        checked = false,
+                    ) { }
+
+                    Spacer(modifier = Modifier.size(8.dp))
+
+                    Text(
+                        text = "약관 전체 동의",
+                        style = NearTheme.typography.B2_14_BOLD,
+                    )
+                }
+
+                Spacer(modifier = Modifier.size(16.dp))
+
+                TermsAgreementSection()
+
+                Spacer(modifier = Modifier.size(32.dp))
+
+                NearBasicButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentPadding = PaddingValues(vertical = 16.dp),
+                    onClick = onConsentComplete,
+                ) {
+                    Text(
+                        text = "가입",
+                        style = NearTheme.typography.B1_16_BOLD,
+                    )
+                }
+
+                Spacer(modifier = Modifier.size(24.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TermsAgreementSection() {
+    val termsList =
+        listOf(
+            "[필수] 서비스 이용 약관",
+            "[필수] 개인정보 수집 및 이용 동의서",
+            "[필수] 개인정보 처리방침",
+        )
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .border(
+                    width = 1.dp,
+                    color = NearTheme.colors.GRAY03_EBEBEB,
+                    shape = RoundedCornerShape(12.dp),
+                ).padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        termsList.forEachIndexed { index, term ->
+            TermsAgreementItem(
+                text = term,
+                isChecked = false,
+                onCheckedChange = { },
+                showDivider = index < termsList.size - 1,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PrivacyConsentBottomSheetPreview() {
+    NearTheme {
+        PrivacyConsentBottomSheet(
+            isVisible = true,
+            onDismiss = { },
+            onConsentComplete = { },
+        )
+    }
+}

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -25,7 +26,6 @@ import com.alarmy.near.R
 import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
 import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
 import com.alarmy.near.presentation.feature.login.model.TermType
-import com.alarmy.near.presentation.feature.login.model.TermsItem
 import com.alarmy.near.presentation.ui.component.button.NearBasicButton
 import com.alarmy.near.presentation.ui.component.checkbox.NearBackgroundCheckbox
 import com.alarmy.near.presentation.ui.extension.onNoRippleClick
@@ -91,7 +91,11 @@ fun PrivacyConsentBottomSheet(
                 // 개별 약관 동의
                 TermsAgreementSection(
                     termsAgreementState = termsAgreementState,
-                    onToggleIndividualTerms = { termType -> viewModel.toggleIndividualTermsAgreement(termType) },
+                    onToggleIndividualTerms = { termType ->
+                        viewModel.toggleIndividualTermsAgreement(
+                            termType,
+                        )
+                    },
                     onShowTermsDetail = { termType -> viewModel.showTermsDetail(termType) },
                 )
 
@@ -141,23 +145,15 @@ private fun TermsAgreementSection(
 ) {
     val requiredPrefix = stringResource(R.string.privacy_consent_required_prefix)
 
-    val termsList = listOf(
-        TermsItem(
-            title = "$requiredPrefix ${stringResource(TermType.SERVICE_TERMS.titleRes)}",
-            termType = TermType.SERVICE_TERMS,
-            isAgreed = termsAgreementState.isServiceTermsAgreed,
-        ),
-        TermsItem(
-            title = "$requiredPrefix ${stringResource(TermType.PRIVACY_COLLECTION.titleRes)}",
-            termType = TermType.PRIVACY_COLLECTION,
-            isAgreed = termsAgreementState.isPrivacyCollectionAgreed,
-        ),
-        TermsItem(
-            title = "$requiredPrefix ${stringResource(TermType.PRIVACY_POLICY.titleRes)}",
-            termType = TermType.PRIVACY_POLICY,
-            isAgreed = termsAgreementState.isPrivacyPolicyAgreed,
-        ),
-    )
+    // 약관 타입 목록을 상수로 정의하여 리컴포지션 시 재생성 방지
+    val terms =
+        remember {
+            listOf(
+                TermType.SERVICE_TERMS,
+                TermType.PRIVACY_COLLECTION,
+                TermType.PRIVACY_POLICY,
+            )
+        }
 
     Column(
         modifier =
@@ -169,13 +165,19 @@ private fun TermsAgreementSection(
                     shape = RoundedCornerShape(12.dp),
                 ).padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
-        termsList.forEachIndexed { index, termsItem ->
+        terms.forEachIndexed { index, termType ->
+            val isAgreed =
+                when (termType) {
+                    TermType.SERVICE_TERMS -> termsAgreementState.isServiceTermsAgreed
+                    TermType.PRIVACY_COLLECTION -> termsAgreementState.isPrivacyCollectionAgreed
+                    TermType.PRIVACY_POLICY -> termsAgreementState.isPrivacyPolicyAgreed
+                }
             TermsAgreementItem(
-                text = termsItem.title,
-                isChecked = termsItem.isAgreed,
-                onCheckedChange = { onToggleIndividualTerms(termsItem.termType) },
-                onclick = { onShowTermsDetail(termsItem.termType) },
-                showDivider = index < termsList.size - 1,
+                text = "$requiredPrefix ${stringResource(termType.titleRes)}",
+                isChecked = isAgreed,
+                onCheckedChange = { onToggleIndividualTerms(termType) },
+                onclick = { onShowTermsDetail(termType) },
+                showDivider = index < terms.size - 1,
             )
         }
     }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -14,12 +14,14 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.alarmy.near.R
 import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
 import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
@@ -35,11 +37,9 @@ fun PrivacyConsentBottomSheet(
     isVisible: Boolean,
     onDismiss: () -> Unit,
     onConsentComplete: () -> Unit,
-    termsAgreementState: TermsAgreementState,
-    onToggleAllTerms: () -> Unit,
-    onToggleIndividualTerms: (TermType) -> Unit,
-    onShowTermsDetail: (TermType) -> Unit,
+    viewModel: LoginViewModel,
 ) {
+    val termsAgreementState by viewModel.termsAgreementState.collectAsStateWithLifecycle()
     if (isVisible) {
         val bottomSheetState =
             rememberModalBottomSheetState(
@@ -75,14 +75,14 @@ fun PrivacyConsentBottomSheet(
                                 width = 1.dp,
                                 color = NearTheme.colors.GRAY03_EBEBEB,
                                 shape = RoundedCornerShape(12.dp),
-                            ).onNoRippleClick(onToggleAllTerms)
+                            ).onNoRippleClick { viewModel.toggleAllTermsAgreement() }
                             .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     // 전체 체크
                     TermsAllCheckAgreementSection(
                         termsAgreementState = termsAgreementState,
-                        onToggleAllTerms = onToggleAllTerms,
+                        onToggleAllTerms = { viewModel.toggleAllTermsAgreement() },
                     )
                 }
 
@@ -91,8 +91,8 @@ fun PrivacyConsentBottomSheet(
                 // 개별 약관 동의
                 TermsAgreementSection(
                     termsAgreementState = termsAgreementState,
-                    onToggleIndividualTerms = onToggleIndividualTerms,
-                    onShowTermsDetail = onShowTermsDetail,
+                    onToggleIndividualTerms = { termType -> viewModel.toggleIndividualTermsAgreement(termType) },
+                    onShowTermsDetail = { termType -> viewModel.showTermsDetail(termType) },
                 )
 
                 Spacer(modifier = Modifier.size(32.dp))
@@ -180,18 +180,4 @@ private fun TermsAgreementSection(
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-fun PrivacyConsentBottomSheetPreview() {
-    NearTheme {
-        PrivacyConsentBottomSheet(
-            isVisible = true,
-            onDismiss = { },
-            onConsentComplete = { },
-            termsAgreementState = TermsAgreementState(),
-            onToggleAllTerms = { },
-            onToggleIndividualTerms = { },
-            onShowTermsDetail = { },
-        )
-    }
-}
+// Preview는 ViewModel이 필요하므로 제거하거나 다른 방식으로 구현

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/PrivacyBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.alarmy.near.presentation.feature.login.components.NearBottomSheetDragHandle
 import com.alarmy.near.presentation.feature.login.components.TermsAgreementItem
+import com.alarmy.near.presentation.feature.login.model.TermType
 import com.alarmy.near.presentation.ui.component.button.NearBasicButton
 import com.alarmy.near.presentation.ui.component.checkbox.NearBackgroundCheckbox
 import com.alarmy.near.presentation.ui.extension.onNoRippleClick

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/NearBottomSheetDragHandle.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/NearBottomSheetDragHandle.kt
@@ -1,0 +1,17 @@
+package com.alarmy.near.presentation.feature.login.components
+
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import com.alarmy.near.presentation.ui.theme.NearTheme
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun NearBottomSheetDragHandle() {
+    BottomSheetDefaults.DragHandle(
+        color = NearTheme.colors.GRAY03_EBEBEB,
+        width = 32.dp,
+        height = 6.dp,
+    )
+}

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/NearBottomSheetDragHandle.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/NearBottomSheetDragHandle.kt
@@ -10,7 +10,9 @@ import com.alarmy.near.presentation.ui.theme.NearTheme
 @OptIn(ExperimentalMaterial3Api::class)
 fun NearBottomSheetDragHandle() {
     BottomSheetDefaults.DragHandle(
-        color = NearTheme.colors.GRAY03_EBEBEB,
+        color = NearTheme.colors.BLACK_1A1A1A.copy(
+            alpha = 0.1f,
+        ),
         width = 32.dp,
         height = 6.dp,
     )

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/TermsAgreementItem.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/TermsAgreementItem.kt
@@ -2,6 +2,7 @@ package com.alarmy.near.presentation.feature.login.components
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
@@ -11,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.alarmy.near.presentation.ui.component.checkbox.NearCheckbox
+import com.alarmy.near.presentation.ui.extension.onNoRippleClick
 import com.alarmy.near.presentation.ui.theme.NearTheme
 
 @Composable
@@ -18,12 +20,16 @@ fun TermsAgreementItem(
     text: String,
     isChecked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
+    onclick: () -> Unit,
     showDivider: Boolean,
 ) {
     Row(
-        modifier = Modifier.padding(vertical = 14.dp),
+        modifier =
+            Modifier
+                .padding(vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        // 체크박스 클릭 시 체크 상태만 변경
         NearCheckbox(
             checked = isChecked,
             onCheckedChange = onCheckedChange,
@@ -31,7 +37,12 @@ fun TermsAgreementItem(
 
         Spacer(modifier = Modifier.size(8.dp))
 
+        // 텍스트 영역 클릭 시 웹뷰로 이동
         Text(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .onNoRippleClick(onclick),
             text = text,
             style = NearTheme.typography.B2_14_MEDIUM,
         )

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/TermsAgreementItem.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/TermsAgreementItem.kt
@@ -1,8 +1,9 @@
 package com.alarmy.near.presentation.feature.login.components
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
@@ -10,7 +11,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.alarmy.near.R
 import com.alarmy.near.presentation.ui.component.checkbox.NearCheckbox
 import com.alarmy.near.presentation.ui.extension.onNoRippleClick
 import com.alarmy.near.presentation.ui.theme.NearTheme
@@ -26,8 +30,10 @@ fun TermsAgreementItem(
     Row(
         modifier =
             Modifier
-                .padding(vertical = 14.dp),
+                .padding(vertical = 14.dp)
+                .onNoRippleClick(onclick),
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         // 체크박스 클릭 시 체크 상태만 변경
         NearCheckbox(
@@ -39,18 +45,35 @@ fun TermsAgreementItem(
 
         // 텍스트 영역 클릭 시 웹뷰로 이동
         Text(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .onNoRippleClick(onclick),
             text = text,
             style = NearTheme.typography.B2_14_MEDIUM,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Image(
+            painter = painterResource(R.drawable.ic_front_24_gray),
+            contentDescription = null,
         )
     }
 
     if (showDivider) {
         HorizontalDivider(
             color = NearTheme.colors.GRAY03_EBEBEB,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TermsAgreementItemPreview() {
+    NearTheme {
+        TermsAgreementItem(
+            text = "개인정보동의~",
+            isChecked = true,
+            onCheckedChange = {},
+            onclick = {},
+            showDivider = true,
         )
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/TermsAgreementItem.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/components/TermsAgreementItem.kt
@@ -1,0 +1,45 @@
+package com.alarmy.near.presentation.feature.login.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.alarmy.near.presentation.ui.component.checkbox.NearCheckbox
+import com.alarmy.near.presentation.ui.theme.NearTheme
+
+@Composable
+fun TermsAgreementItem(
+    text: String,
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    showDivider: Boolean,
+) {
+    Row(
+        modifier = Modifier.padding(vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        NearCheckbox(
+            checked = isChecked,
+            onCheckedChange = onCheckedChange,
+        )
+
+        Spacer(modifier = Modifier.size(8.dp))
+
+        Text(
+            text = text,
+            style = NearTheme.typography.B2_14_MEDIUM,
+        )
+    }
+
+    if (showDivider) {
+        HorizontalDivider(
+            color = NearTheme.colors.GRAY03_EBEBEB,
+        )
+    }
+}

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/model/TermType.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/model/TermType.kt
@@ -1,0 +1,26 @@
+package com.alarmy.near.presentation.feature.login.model
+
+import androidx.annotation.StringRes
+import com.alarmy.near.BuildConfig
+import com.alarmy.near.R
+
+/**
+ * 약관 및 정책 타입
+ */
+enum class TermType(
+    @StringRes val titleRes: Int,
+    val url: String,
+) {
+    SERVICE_TERMS(
+        titleRes = R.string.terms_service_agreed,
+        url = BuildConfig.SERVICE_AGREED_TERMS_URL,
+    ),
+    PRIVACY_COLLECTION(
+        titleRes = R.string.terms_personal_info,
+        url = BuildConfig.PERSONAL_INFO_TERMS_URL,
+    ),
+    PRIVACY_POLICY(
+        titleRes = R.string.terms_privacy_policy,
+        url = BuildConfig.PRIVACY_POLICY_TERMS_URL,
+    ),
+}

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/model/TermsItem.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/model/TermsItem.kt
@@ -1,0 +1,10 @@
+package com.alarmy.near.presentation.feature.login.model
+
+/**
+ * 약관 항목 정보
+ */
+data class TermsItem(
+    val title: String,
+    val termType: TermType,
+    val isAgreed: Boolean,
+)

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/navigation/LoginNavigation.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/navigation/LoginNavigation.kt
@@ -25,6 +25,7 @@ fun NavGraphBuilder.loginNavGraph(
         LoginRoute(
             onNavigateToHome = onNavigateToHome,
             onNavigateToWebView = onNavigateToTerms,
+            onShowErrorSnackBar = onShowErrorSnackBar,
         )
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/navigation/LoginNavigation.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/navigation/LoginNavigation.kt
@@ -18,11 +18,13 @@ fun NavController.navigateToLogin(navOptions: NavOptions? = null) {
 // 로그인 화면 NavGraph 정의
 fun NavGraphBuilder.loginNavGraph(
     onNavigateToHome: () -> Unit,
+    onNavigateToTerms: (title: String, url: String) -> Unit,
     onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
 ) {
     composable<RouteLogin> {
         LoginRoute(
             onNavigateToHome = onNavigateToHome,
+            onNavigateToWebView = onNavigateToTerms,
         )
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/main/NearNavHost.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/main/NearNavHost.kt
@@ -9,7 +9,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.alarmy.near.presentation.feature.contact.navigation.CONTACT_SELECTION_COMPLETE_KEY
-import com.alarmy.near.presentation.feature.contact.navigation.RouteContact
 import com.alarmy.near.presentation.feature.contact.navigation.contactNavGraph
 import com.alarmy.near.presentation.feature.friendprofile.navigation.friendProfileNavGraph
 import com.alarmy.near.presentation.feature.friendprofile.navigation.navigateToFriendProfile
@@ -62,7 +61,6 @@ internal fun NearNavHost(
 
         // 로그인 화면 NavGraph
         loginNavGraph(
-            onShowErrorSnackBar = onShowSnackbar,
             onNavigateToHome = {
                 navController.navigateToHome(
                     navOptions =
@@ -71,6 +69,10 @@ internal fun NearNavHost(
                         },
                 )
             },
+            onNavigateToTerms = { title, url ->
+                navController.navigateToWebView(title, url)
+            },
+            onShowErrorSnackBar = onShowSnackbar,
         )
 
         // 홈 화면 NavGraph
@@ -145,30 +147,6 @@ internal fun NearNavHost(
             )
             navController.popBackStack()
         })
-
-        // 로그인 화면 NavGraph
-        loginNavGraph(
-            onShowErrorSnackBar = onShowSnackbar,
-            onNavigateToHome = {
-                navController.navigateToHome(
-                    navOptions =
-                        navOptions {
-                            popUpTo(RouteLogin) { inclusive = true }
-                        },
-                )
-            },
-        )
-
-        // 홈 화면 NavGraph
-        homeNavGraph(
-            onShowErrorSnackBar = onShowSnackbar,
-            onContactClick = { contactId ->
-                navController.navigateToFriendProfile(friendId = contactId)
-            },
-            onMyPageClick = {},
-            onAlarmClick = {},
-            onAddContactClick = {},
-        )
 
         contactNavGraph(
             onShowErrorSnackBar = onShowSnackbar,

--- a/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/WebViewFrame.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/WebViewFrame.kt
@@ -1,20 +1,26 @@
 package com.alarmy.near.presentation.ui.component
 
+import android.graphics.Bitmap
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.alarmy.near.presentation.ui.component.appbar.NearCancelTopAppBar
+import com.alarmy.near.presentation.ui.theme.NearTheme
 
 @Composable
 fun WebViewFrame(
@@ -25,6 +31,7 @@ fun WebViewFrame(
 ) {
     var canGoBack by remember { mutableStateOf(false) }
     var webView: WebView? by remember { mutableStateOf(null) }
+    var isLoading by remember { mutableStateOf(true) }
 
     BackHandler(enabled = canGoBack) {
         webView?.goBack()
@@ -32,38 +39,66 @@ fun WebViewFrame(
 
     NearFrame {
         NearCancelTopAppBar(
-            modifier = Modifier.padding(horizontal = 24.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
             title = title,
             onCancelClick = onNavigateBack,
         )
 
-        AndroidView(
-            modifier = modifier.fillMaxSize(),
-            factory = { context ->
-                WebView(context).apply {
-                    webView = this
-                    webViewClient = object : WebViewClient() {
-                        override fun onPageFinished(view: WebView?, url: String?) {
-                            super.onPageFinished(view, url)
-                            // 페이지 로드 완료 시 뒤로가기 가능 상태 업데이트
-                            canGoBack = view?.canGoBack() ?: false
+        Box(
+            modifier = modifier.weight(1f),
+        ) {
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = { context ->
+                    WebView(context).apply {
+                        webView = this
+                        webViewClient =
+                            object : WebViewClient() {
+                                override fun onPageStarted(
+                                    view: WebView?,
+                                    url: String?,
+                                    favicon: Bitmap?,
+                                ) {
+                                    super.onPageStarted(view, url, favicon)
+                                    isLoading = true
+                                }
+
+                                override fun onPageFinished(
+                                    view: WebView?,
+                                    url: String?,
+                                ) {
+                                    super.onPageFinished(view, url)
+                                    canGoBack = view?.canGoBack() ?: false
+                                    isLoading = false
+                                }
+                            }
+                        settings.apply {
+                            domStorageEnabled = true
+                            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                            loadWithOverviewMode = true
+                            useWideViewPort = true
+                            builtInZoomControls = true
+                            displayZoomControls = false
                         }
+                        loadUrl(url)
                     }
-                    settings.apply {
-                        domStorageEnabled = true
-                        mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-                        loadWithOverviewMode = true
-                        useWideViewPort = true
-                        builtInZoomControls = true
-                        displayZoomControls = false
-                    }
-                    loadUrl(url)
-                }
-            },
-            update = { view ->
-                // WebView 업데이트 시 뒤로가기 가능 상태 동기화
-                canGoBack = view.canGoBack()
+                },
+                update = { view ->
+                    // WebView 업데이트 시 뒤로가기 가능 상태 동기화
+                    canGoBack = view.canGoBack()
+                },
+            )
+
+            // 로딩 중일 때 중앙에 로딩 인디케이터 표시
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center),
+                    color = NearTheme.colors.BLUE01_5AA2E9,
+                )
             }
-        )
+        }
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/checkbox/NearCheckbox.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/checkbox/NearCheckbox.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.alarmy.near.R
+import com.alarmy.near.presentation.ui.extension.onNoRippleClick
 
 @Composable
 fun NearCheckbox(
@@ -21,7 +22,7 @@ fun NearCheckbox(
 ) {
     Image(
         modifier =
-            modifier.clickable(
+            modifier.onNoRippleClick(
                 onClick = { onCheckedChange(!checked) },
             ),
         painter =

--- a/Near/app/src/main/res/values/strings.xml
+++ b/Near/app/src/main/res/values/strings.xml
@@ -131,6 +131,12 @@
     <string name="terms_service_agreed">서비스 이용약관</string>
     <string name="terms_personal_info">개인정보 수집 및 이용동의</string>
     <string name="terms_privacy_policy">개인정보 처리방침</string>
+    
+    <!-- 개인정보 동의 바텀시트 (Privacy Consent BottomSheet) -->
+    <string name="privacy_consent_title">서비스 약관 동의</string>
+    <string name="privacy_consent_all_agreement">약관 전체 동의</string>
+    <string name="privacy_consent_required_prefix">[필수]</string>
+    <string name="privacy_consent_signup_button">가입</string>
 
     <!-- 로그인 타입 (Login Type) -->
     <string name="login_type_kakao">카카오</string>


### PR DESCRIPTION
## 작업 내용
- 로그인 성공 후 바텀시트를 열어 개인정보를 동의합니다.
- 체크박스 전체가 체크되어야 버튼이 활성화 됩니다.
- 각 항목을 클릭하면 웹뷰로 전환됩니다.
- 웹뷰에서 다시 복귀했을 때 바텀시트를 유지합니다.

<table>
  <tr>
    <td align="center">
     <img width="300" alt="image" src="https://github.com/user-attachments/assets/d027f145-24da-4267-afd8-148d117001bd" /><br>
      체크 안됨
    </td>
    <td align="center">
<img width="300" height="1447" alt="image" src="https://github.com/user-attachments/assets/07f85df6-dc6f-4f54-a670-2a087f410c08" /><br>
      전체 체크 완료
    </td>
  </tr>
</table>


## 확인 방법
- feature/login 에 PrivacyConsentBottomSheet를 구성하였습니다.

## 참고 사항
- 로그인 성공 후 바텀시트를 열게 되는데 내리면 로그인도 실패처리를 해야하는지
- 바텀시트가 내려가지 않게 해야하는지 이야기해보면 좋을 것 같습니다!
- 개인정보 동의 상태를 따로 저장하거나 하지 않고 ui단에서만 처리하고 있습니다.
-  현재는 동의 후 **다음** 버튼을 클릭하면 **홈화면** 으로 이동하게 되는데, 연락처 주기 설정 화면으로 구성하는 것은 feat/friend-contact-cycle 브랜치에서 담당합니다.

## 관련 이슈
- close #30 
