### PR TITLE
[FEAT] 프로필 수정, 회원 탈퇴 시 다이얼로그 추가

### DIFF
--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendcontactcycle/FriendContactCycleScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendcontactcycle/FriendContactCycleScreen.kt
@@ -230,11 +230,8 @@ fun FriendContactCycleScreen(
     // 권한 거부 다이얼로그 표시
     if (uiState.showPermissionDeniedDialog) {
         ContactPermissionDeniedDialog(
-            onDismiss = {
-                onHidePermissionDeniedDialog()
-            },
+            onDismiss = onHidePermissionDeniedDialog,
             onGoToSettings = {
-                onHidePermissionDeniedDialog()
                 AppSettingsUtil.openAppSettings(context)
             },
         )

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendcontactcycle/components/ContactPermissionDeniedDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendcontactcycle/components/ContactPermissionDeniedDialog.kt
@@ -22,7 +22,7 @@ fun ContactPermissionDeniedDialog(
         dismissButtonText = stringResource(R.string.contact_permission_cancel),
         confirmButtonText = stringResource(R.string.contact_permission_go_to_settings),
         onDismissButtonClick = onDismiss,
-        onConfirmButtonClick = onGoToSettings,
+        onConfirm = onGoToSettings,
     )
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/FriendProfileEditorScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/FriendProfileEditorScreen.kt
@@ -8,13 +8,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -29,7 +26,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -54,6 +50,7 @@ import com.alarmy.near.presentation.feature.friendprofileedittor.uistate.FriendP
 import com.alarmy.near.presentation.feature.friendprofileedittor.uistate.FriendProfileEditorUIState
 import com.alarmy.near.presentation.ui.component.NearFrame
 import com.alarmy.near.presentation.ui.component.appbar.NearTopAppbar
+import com.alarmy.near.presentation.ui.component.dialog.NearBasicDialog
 import com.alarmy.near.presentation.ui.component.radiobutton.NearSmallRadioButton
 import com.alarmy.near.presentation.ui.component.textfield.NearLimitedTextField
 import com.alarmy.near.presentation.ui.component.textfield.NearTextField
@@ -70,6 +67,7 @@ fun FriendProfileEditorRoute(
 ) {
     val friendProfileEditorUIState = viewModel.uiState.collectAsStateWithLifecycle()
     val warningDialogState = remember { mutableStateOf(false) }
+    val saveConfirmDialogState = remember { mutableStateOf(false) }
     val context = LocalContext.current
 
     LaunchedEffect(viewModel.uiEvent) {
@@ -103,6 +101,7 @@ fun FriendProfileEditorRoute(
     FriendProfileEditorScreen(
         friendProfileEditorUIState = friendProfileEditorUIState.value,
         dialogState = warningDialogState.value,
+        saveConfirmDialogState = saveConfirmDialogState.value,
         onClickBackButton = viewModel::onExit,
         onNameChanged = viewModel::onNameChanged,
         onRelationChanged = viewModel::onRelationChanged,
@@ -116,6 +115,7 @@ fun FriendProfileEditorRoute(
         onSubmit = viewModel::onSubmit,
         onEditorExit = onClickBackButton,
         onCloseDialog = { warningDialogState.value = false },
+        onSaveConfirmDialogStateChanged = { saveConfirmDialogState.value = it },
     )
 }
 
@@ -124,6 +124,7 @@ fun FriendProfileEditorRoute(
 fun FriendProfileEditorScreen(
     modifier: Modifier = Modifier,
     dialogState: Boolean = false,
+    saveConfirmDialogState: Boolean = false,
     friendProfileEditorUIState: FriendProfileEditorUIState,
     onClickBackButton: () -> Unit = {},
     onNameChanged: (String) -> Unit = {},
@@ -138,6 +139,7 @@ fun FriendProfileEditorScreen(
     onSubmit: () -> Unit = {},
     onEditorExit: () -> Unit = {},
     onCloseDialog: () -> Unit = {},
+    onSaveConfirmDialogStateChanged: (Boolean) -> Unit = {},
 ) {
     val showBottomSheet = remember { mutableStateOf(false) }
     if (showBottomSheet.value) {
@@ -158,6 +160,20 @@ fun FriendProfileEditorScreen(
             },
         )
     }
+
+    if (saveConfirmDialogState) {
+        NearBasicDialog(
+            onDismiss = { onSaveConfirmDialogStateChanged(false) },
+            body = stringResource(R.string.editor_save_confirm_content),
+            dismissButtonText = stringResource(R.string.editor_save_confirm_cancel),
+            confirmButtonText = stringResource(R.string.editor_save_confirm_save),
+            onDismissButtonClick = { onSaveConfirmDialogStateChanged(false) },
+            onConfirmButtonClick = {
+                onSaveConfirmDialogStateChanged(false)
+                onSubmit()
+            },
+        )
+    }
     NearFrame(modifier = modifier) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
@@ -169,7 +185,7 @@ fun FriendProfileEditorScreen(
                         Text(
                             modifier =
                                 Modifier.onNoRippleClick(onClick = {
-                                    onSubmit()
+                                    onSaveConfirmDialogStateChanged(true)
                                 }),
                             text = stringResource(R.string.friend_profile_editor_edit_complete_text),
                             style = NearTheme.typography.B1_16_BOLD,

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/FriendProfileEditorScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/FriendProfileEditorScreen.kt
@@ -164,10 +164,7 @@ fun FriendProfileEditorScreen(
     if (saveConfirmDialogState) {
         SaveConfirmDialog(
             onDismissRequest = { onSaveConfirmDialogStateChanged(false) },
-            onConfirm = {
-                onSaveConfirmDialogStateChanged(false)
-                onSubmit()
-            },
+            onConfirm = onSubmit,
         )
     }
     NearFrame(modifier = modifier) {

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/FriendProfileEditorScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/FriendProfileEditorScreen.kt
@@ -46,11 +46,11 @@ import com.alarmy.near.model.ReminderInterval
 import com.alarmy.near.presentation.feature.friendprofileedittor.component.NearDatePicker
 import com.alarmy.near.presentation.feature.friendprofileedittor.component.ReminderIntervalBottomSheet
 import com.alarmy.near.presentation.feature.friendprofileedittor.dialog.EditorExitDialog
+import com.alarmy.near.presentation.feature.friendprofileedittor.dialog.SaveConfirmDialog
 import com.alarmy.near.presentation.feature.friendprofileedittor.uistate.FriendProfileEditorUIEvent
 import com.alarmy.near.presentation.feature.friendprofileedittor.uistate.FriendProfileEditorUIState
 import com.alarmy.near.presentation.ui.component.NearFrame
 import com.alarmy.near.presentation.ui.component.appbar.NearTopAppbar
-import com.alarmy.near.presentation.ui.component.dialog.NearBasicDialog
 import com.alarmy.near.presentation.ui.component.radiobutton.NearSmallRadioButton
 import com.alarmy.near.presentation.ui.component.textfield.NearLimitedTextField
 import com.alarmy.near.presentation.ui.component.textfield.NearTextField
@@ -162,13 +162,9 @@ fun FriendProfileEditorScreen(
     }
 
     if (saveConfirmDialogState) {
-        NearBasicDialog(
-            onDismiss = { onSaveConfirmDialogStateChanged(false) },
-            body = stringResource(R.string.editor_save_confirm_content),
-            dismissButtonText = stringResource(R.string.editor_save_confirm_cancel),
-            confirmButtonText = stringResource(R.string.editor_save_confirm_save),
-            onDismissButtonClick = { onSaveConfirmDialogStateChanged(false) },
-            onConfirmButtonClick = {
+        SaveConfirmDialog(
+            onDismissRequest = { onSaveConfirmDialogStateChanged(false) },
+            onConfirm = {
                 onSaveConfirmDialogStateChanged(false)
                 onSubmit()
             },

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/EditorExitDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/EditorExitDialog.kt
@@ -21,7 +21,7 @@ internal fun EditorExitDialog(
         dismissButtonText = stringResource(R.string.editor_exit_dismiss),
         confirmButtonText = stringResource(R.string.editor_exit_confirm),
         onDismissButtonClick = onDismissRequest,
-        onConfirmButtonClick = onConfirm,
+        onConfirm = onConfirm,
     )
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/EditorExitDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/EditorExitDialog.kt
@@ -1,15 +1,11 @@
 package com.alarmy.near.presentation.feature.friendprofileedittor.dialog
 
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.alarmy.near.R
+import com.alarmy.near.presentation.ui.component.dialog.NearBasicDialog
 import com.alarmy.near.presentation.ui.theme.NearTheme
 
 @Composable
@@ -18,33 +14,14 @@ internal fun EditorExitDialog(
     onDismissRequest: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-    AlertDialog(
-        modifier = modifier,
-        onDismissRequest = onDismissRequest,
-        title = {
-            Text(text = stringResource(R.string.editor_exit_title))
-        },
-        text = {
-            Text(
-                text =
-                    stringResource(R.string.editor_exit_content),
-            )
-        },
-        confirmButton = {
-            TextButton(
-                onClick = onConfirm,
-            ) {
-                Text(stringResource(R.string.editor_exit_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(stringResource(R.string.editor_exit_dismiss))
-            }
-        },
-        shape = RoundedCornerShape(24.dp),
+    NearBasicDialog(
+        onDismiss = onDismissRequest,
+        title = stringResource(R.string.editor_exit_title),
+        body = stringResource(R.string.editor_exit_content),
+        dismissButtonText = stringResource(R.string.editor_exit_dismiss),
+        confirmButtonText = stringResource(R.string.editor_exit_confirm),
+        onDismissButtonClick = onDismissRequest,
+        onConfirmButtonClick = onConfirm,
     )
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/SaveConfirmDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/SaveConfirmDialog.kt
@@ -1,0 +1,36 @@
+package com.alarmy.near.presentation.feature.friendprofileedittor.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.alarmy.near.R
+import com.alarmy.near.presentation.ui.component.dialog.NearBasicDialog
+import com.alarmy.near.presentation.ui.theme.NearTheme
+
+@Composable
+internal fun SaveConfirmDialog(
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    NearBasicDialog(
+        onDismiss = onDismissRequest,
+        body = stringResource(R.string.editor_save_confirm_content),
+        dismissButtonText = stringResource(R.string.editor_save_confirm_cancel),
+        confirmButtonText = stringResource(R.string.editor_save_confirm_save),
+        onDismissButtonClick = onDismissRequest,
+        onConfirmButtonClick = onConfirm,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SaveConfirmDialogPreview() {
+    NearTheme {
+        SaveConfirmDialog(
+            onDismissRequest = { },
+            onConfirm = {},
+        )
+    }
+}

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/SaveConfirmDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/friendprofileedittor/dialog/SaveConfirmDialog.kt
@@ -20,7 +20,7 @@ internal fun SaveConfirmDialog(
         dismissButtonText = stringResource(R.string.editor_save_confirm_cancel),
         confirmButtonText = stringResource(R.string.editor_save_confirm_save),
         onDismissButtonClick = onDismissRequest,
-        onConfirmButtonClick = onConfirm,
+        onConfirm = onConfirm,
     )
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/WithdrawScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/WithdrawScreen.kt
@@ -191,10 +191,7 @@ fun WithdrawScreen(
     if (withdrawConfirmDialogState) {
         WithdrawConfirmDialog(
             onDismissRequest = { onWithdrawConfirmDialogStateChanged(false) },
-            onConfirm = {
-                onWithdrawConfirmDialogStateChanged(false)
-                onSubmitWithdrawRequest()
-            },
+            onConfirm = onSubmitWithdrawRequest,
         )
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/WithdrawScreen.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/WithdrawScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -22,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.alarmy.near.R
+import com.alarmy.near.presentation.feature.myprofile.dialog.WithdrawConfirmDialog
 import com.alarmy.near.presentation.feature.myprofile.model.WithdrawReason
 import com.alarmy.near.presentation.ui.component.NearFrame
 import com.alarmy.near.presentation.ui.component.appbar.NearCancelTopAppBar
@@ -41,6 +43,7 @@ fun WithdrawRoute(
     onShowErrorSnackBar: (Throwable?) -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val withdrawConfirmDialogState = remember { mutableStateOf(false) }
 
     // 통합된 이벤트 처리
     LaunchedEffect(viewModel.uiEvent) {
@@ -61,20 +64,24 @@ fun WithdrawRoute(
 
     WithdrawScreen(
         uiState = uiState,
+        withdrawConfirmDialogState = withdrawConfirmDialogState.value,
         onSelectReason = viewModel::selectReason,
         onUpdateOtherReasonText = viewModel::updateOtherReasonText,
         onSubmitWithdrawRequest = viewModel::submitWithdrawRequest,
         onNavigateBack = viewModel::onNavigateBack,
+        onWithdrawConfirmDialogStateChanged = { withdrawConfirmDialogState.value = it },
     )
 }
 
 @Composable
 fun WithdrawScreen(
     uiState: WithdrawUiState,
+    withdrawConfirmDialogState: Boolean = false,
     onSelectReason: (WithdrawReason) -> Unit,
     onUpdateOtherReasonText: (String) -> Unit,
     onSubmitWithdrawRequest: () -> Unit,
     onNavigateBack: () -> Unit,
+    onWithdrawConfirmDialogStateChanged: (Boolean) -> Unit = {},
 ) {
     // 4개의 탈퇴 사유 리스트 생성
     val withdrawReasons = remember { WithdrawReason.entries }
@@ -171,13 +178,24 @@ fun WithdrawScreen(
                 modifier = Modifier.weight(1f),
                 enabled = uiState.isWithdrawButtonEnabled,
                 onClick = {
-                    onSubmitWithdrawRequest()
+                    onWithdrawConfirmDialogStateChanged(true)
                 },
                 text = stringResource(R.string.withdraw_confirm_button),
                 contentPadding = PaddingValues(vertical = 16.dp),
             )
         }
         Spacer(modifier = Modifier.size(24.dp))
+    }
+    
+    // 탈퇴 확인 다이얼로그
+    if (withdrawConfirmDialogState) {
+        WithdrawConfirmDialog(
+            onDismissRequest = { onWithdrawConfirmDialogStateChanged(false) },
+            onConfirm = {
+                onWithdrawConfirmDialogStateChanged(false)
+                onSubmitWithdrawRequest()
+            },
+        )
     }
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/dialog/WithdrawConfirmDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/dialog/WithdrawConfirmDialog.kt
@@ -21,7 +21,7 @@ internal fun WithdrawConfirmDialog(
         dismissButtonText = stringResource(R.string.withdraw_confirm_cancel),
         confirmButtonText = stringResource(R.string.withdraw_confirm_withdraw),
         onDismissButtonClick = onDismissRequest,
-        onConfirmButtonClick = onConfirm,
+        onConfirm = onConfirm,
     )
 }
 

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/dialog/WithdrawConfirmDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/myprofile/dialog/WithdrawConfirmDialog.kt
@@ -1,0 +1,37 @@
+package com.alarmy.near.presentation.feature.myprofile.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.alarmy.near.R
+import com.alarmy.near.presentation.ui.component.dialog.NearOutlinedDialog
+import com.alarmy.near.presentation.ui.theme.NearTheme
+
+@Composable
+internal fun WithdrawConfirmDialog(
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    NearOutlinedDialog(
+        onDismiss = onDismissRequest,
+        title = null,
+        body = stringResource(R.string.withdraw_confirm_content),
+        dismissButtonText = stringResource(R.string.withdraw_confirm_cancel),
+        confirmButtonText = stringResource(R.string.withdraw_confirm_withdraw),
+        onDismissButtonClick = onDismissRequest,
+        onConfirmButtonClick = onConfirm,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun WithdrawConfirmDialogPreview() {
+    NearTheme {
+        WithdrawConfirmDialog(
+            onDismissRequest = { },
+            onConfirm = {},
+        )
+    }
+}

--- a/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/dialog/NearBasicDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/dialog/NearBasicDialog.kt
@@ -25,7 +25,7 @@ fun NearBasicDialog(
     dismissButtonText: String,
     confirmButtonText: String,
     onDismissButtonClick: (() -> Unit),
-    onConfirmButtonClick: (() -> Unit),
+    onConfirm: (() -> Unit),
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -66,7 +66,10 @@ fun NearBasicDialog(
 
                 NearBasicButton(
                     modifier = Modifier.weight(1f),
-                    onClick = onConfirmButtonClick,
+                    onClick = {
+                        onConfirm()
+                        onDismiss()
+                    },
                     contentPadding = PaddingValues(16.dp),
                 ) {
                     Text(
@@ -92,7 +95,7 @@ fun NearBasicDialogPreview() {
             dismissButtonText = "취소",
             confirmButtonText = "설정으로 이동",
             onDismissButtonClick = {},
-            onConfirmButtonClick = {},
+            onConfirm = {},
         )
     }
 }

--- a/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/dialog/NearOutlinedDialog.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/dialog/NearOutlinedDialog.kt
@@ -25,7 +25,7 @@ fun NearOutlinedDialog(
     dismissButtonText: String,
     confirmButtonText: String,
     onDismissButtonClick: (() -> Unit),
-    onConfirmButtonClick: (() -> Unit),
+    onConfirm: (() -> Unit),
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -72,7 +72,10 @@ fun NearOutlinedDialog(
                     contentPadding = PaddingValues(16.dp),
                     enabled = true,
                     text = confirmButtonText,
-                    onClick = onConfirmButtonClick,
+                    onClick = {
+                        onConfirm()
+                        onDismiss()
+                    },
                 )
             }
         },
@@ -92,7 +95,7 @@ fun NearOutlinedDialogPreview() {
             confirmButtonText = "취소",
             dismissButtonText = "설정으로 이동",
             onDismissButtonClick = {},
-            onConfirmButtonClick = {},
+            onConfirm = {},
         )
     }
 }

--- a/Near/app/src/main/res/values/strings.xml
+++ b/Near/app/src/main/res/values/strings.xml
@@ -128,6 +128,11 @@
     <string name="withdraw_other_reason_placeholder">편하게 의견을 남겨주세요.</string>
     <string name="withdraw_cancel_button">그만두기</string>
     <string name="withdraw_confirm_button">탈퇴하기</string>
+    
+    <!-- withdraw confirm dialog   -->
+    <string name="withdraw_confirm_content">탈퇴 시 계정 및 이용 내역이\n모두 삭제되며, 복구가 불가능합니다.\n정말 탈퇴하시겠습니까?</string>
+    <string name="withdraw_confirm_cancel">취소</string>
+    <string name="withdraw_confirm_withdraw">탈퇴하기</string>
 
     <!-- 텍스트필드 (TextField) -->
     <string name="textfield_error_message">1글자 이상 입력해주세요.</string>

--- a/Near/app/src/main/res/values/strings.xml
+++ b/Near/app/src/main/res/values/strings.xml
@@ -92,6 +92,11 @@
     <string name="editor_exit_content">화면을 나가면 \n수정 내용은 저장되지 않아요.</string>
     <string name="editor_exit_confirm">확인</string>
     <string name="editor_exit_dismiss">취소</string>
+    
+    <!-- editor save confirm dialog   -->
+    <string name="editor_save_confirm_content">수정을 완료하시겠습니까?</string>
+    <string name="editor_save_confirm_save">저장</string>
+    <string name="editor_save_confirm_cancel">취소</string>
     <string name="day_of_week_monday">월요일</string>
     <string name="day_of_week_tuesday">화요일</string>
     <string name="day_of_week_wednesday">수요일</string>


### PR DESCRIPTION
## 작업 내용
- FriendProfileEditorScreen에서 수정한 값이 있을 때 앱바 네비게이션 버튼을 클린한 경우 표시되는 다이얼로그를 NearBasicDialog로 수정하였습니다.
- FriendProfileEditorScreen에서 수정을 완료하였을 때 확인 다이얼로그를 표시합니다.
- WithdrawScreen에서 "탈퇴하기" 버튼을 클릭했을 때 확인 다이얼로그를 표시합니다.

## 확인 방법
feature/friendprofileeditor/dialog, FriendProfileEditorScreen
feature/myprofile/dialog, WithdrawScreen
에서 추가된 다이얼로그와 반영 코드를 확인하실 수 있습니다.

## 참고 사항
- 추후 다이얼로그 문구가 변경될 수 있습니

## 관련 이슈
- close #39 
