### PR TITLE
[FIX] 카카오 소셜 로그인 SDK 로직 개선

### DIFF
--- a/Near/app/src/main/java/com/alarmy/near/data/datasource/KakaoDataSource.kt
+++ b/Near/app/src/main/java/com/alarmy/near/data/datasource/KakaoDataSource.kt
@@ -29,6 +29,8 @@ class KakaoDataSource
 
         override suspend fun login(): Result<String> =
             try {
+                unlinkKakaoAccount()
+
                 // Activity Context 우선 사용, 없으면 Application Context 사용
                 val activityContext = activityContextProvider.getActivityContext()
                 val context = activityContext ?: applicationContext
@@ -47,6 +49,16 @@ class KakaoDataSource
                 }
             } catch (exception: Exception) {
                 Result.failure(exception)
+            }
+
+        /**
+         * 카카오 계정 연결 끊기
+         */
+        private suspend fun unlinkKakaoAccount() =
+            suspendCancellableCoroutine { continuation ->
+                UserApiClient.instance.unlink { error ->
+                    continuation.resume(Unit)
+                }
             }
 
         private suspend fun loginWithKakaoTalk(context: Context): String =

--- a/Near/app/src/main/java/com/alarmy/near/data/datasource/KakaoDataSource.kt
+++ b/Near/app/src/main/java/com/alarmy/near/data/datasource/KakaoDataSource.kt
@@ -1,6 +1,7 @@
 package com.alarmy.near.data.datasource
 
 import android.content.Context
+import com.alarmy.near.data.provider.ActivityContextProvider
 import com.alarmy.near.model.ProviderType
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
@@ -21,17 +22,22 @@ import kotlin.coroutines.resume
 class KakaoDataSource
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
+        @ApplicationContext private val applicationContext: Context,
+        private val activityContextProvider: ActivityContextProvider,
     ) : SocialLoginDataSource {
         override val supportedType: ProviderType = ProviderType.KAKAO
 
         override suspend fun login(): Result<String> =
             try {
+                // Activity Context 우선 사용, 없으면 Application Context 사용
+                val activityContext = activityContextProvider.getActivityContext()
+                val context = activityContext ?: applicationContext
+
                 val token =
                     if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-                        loginWithKakaoTalk()
+                        loginWithKakaoTalk(context)
                     } else {
-                        loginWithKakaoAccount()
+                        loginWithKakaoAccount(context)
                     }
 
                 if (token.isNotEmpty()) {
@@ -43,18 +49,12 @@ class KakaoDataSource
                 Result.failure(exception)
             }
 
-        private suspend fun loginWithKakaoTalk(): String =
+        private suspend fun loginWithKakaoTalk(context: Context): String =
             suspendCancellableCoroutine { continuation ->
                 UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
                     when {
                         error != null -> {
-                            if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                                continuation.resume("")
-                            } else {
-                                UserApiClient.instance.loginWithKakaoAccount(context) { retryToken, retryError ->
-                                    handleLoginResult(retryToken, retryError, continuation)
-                                }
-                            }
+                            continuation.resume("")
                         }
                         token != null -> continuation.resume(token.accessToken)
                         else -> continuation.resume("")
@@ -62,7 +62,7 @@ class KakaoDataSource
                 }
             }
 
-        private suspend fun loginWithKakaoAccount(): String =
+        private suspend fun loginWithKakaoAccount(context: Context): String =
             suspendCancellableCoroutine { continuation ->
                 UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
                     handleLoginResult(token, error, continuation)

--- a/Near/app/src/main/java/com/alarmy/near/data/di/ContextProviderModule.kt
+++ b/Near/app/src/main/java/com/alarmy/near/data/di/ContextProviderModule.kt
@@ -1,0 +1,22 @@
+package com.alarmy.near.data.di
+
+import com.alarmy.near.data.provider.ActivityContextProvider
+import com.alarmy.near.presentation.provider.ActivityContextProviderImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Context Provider 모듈
+ * Activity Context 제공을 위한 의존성 주입 설정
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+interface ContextProviderModule {
+    @Binds
+    @Singleton
+    fun bindActivityContextProvider(impl: ActivityContextProviderImpl): ActivityContextProvider
+}
+

--- a/Near/app/src/main/java/com/alarmy/near/data/provider/ActivityContextProvider.kt
+++ b/Near/app/src/main/java/com/alarmy/near/data/provider/ActivityContextProvider.kt
@@ -1,0 +1,16 @@
+package com.alarmy.near.data.provider
+
+import android.content.Context
+
+/**
+ * Activity Context 제공 인터페이스
+ * 카카오 로그인 등 Activity Context가 필요한 경우에 사용
+ */
+interface ActivityContextProvider {
+    /**
+     * 현재 Activity의 Context를 반환
+     * Activity Context, 없으면 null
+     */
+    fun getActivityContext(): Context?
+}
+

--- a/Near/app/src/main/java/com/alarmy/near/data/repository/AuthRepository.kt
+++ b/Near/app/src/main/java/com/alarmy/near/data/repository/AuthRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
     // 소셜 로그인 수행
-    suspend fun performSocialLogin(providerType: ProviderType): Result<Unit>
+    suspend fun performSocialLogin(providerType: ProviderType): Result<String>
 
     /**
      * 소셜 로그인 수행 (토큰 직접 전달)

--- a/Near/app/src/main/java/com/alarmy/near/data/repository/AuthRepositoryImpl.kt
+++ b/Near/app/src/main/java/com/alarmy/near/data/repository/AuthRepositoryImpl.kt
@@ -16,13 +16,13 @@ class AuthRepositoryImpl
         private val socialLoginProcessor: SocialLoginProcessor,
         private val tokenManager: TokenManager,
     ) : AuthRepository {
-        override suspend fun performSocialLogin(providerType: ProviderType): Result<Unit> =
+        override suspend fun performSocialLogin(providerType: ProviderType): Result<String> =
             try {
                 val result = socialLoginProcessor.processLogin(providerType)
 
                 if (result.isSuccess) {
                     val accessToken = result.getOrThrow()
-                    socialLogin(accessToken, providerType)
+                    Result.success(accessToken)
                 } else {
                     Result.failure(
                         createLoginException(

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -35,6 +35,10 @@ class LoginViewModel
         private val _loginState = MutableStateFlow(LoginState())
         val loginState: StateFlow<LoginState> = _loginState.asStateFlow()
 
+        // 임시 토큰 저장 (개인정보 동의 전)
+        private var tempAccessToken: String? = null
+        private var tempProviderType: ProviderType? = null
+
         // 개별 상태들을 편의를 위해 노출
         val termsAgreementState: StateFlow<TermsAgreementState> =
             _loginState
@@ -61,8 +65,12 @@ class LoginViewModel
                 updateLoadingState(isLoading = true)
                 authRepository
                     .performSocialLogin(providerType)
-                    .onSuccess {
+                    .onSuccess { accessToken ->
                         updateLoadingState(isLoading = false)
+                        // 토큰을 ViewModel 내부에 임시 저장
+                        tempAccessToken = accessToken
+                        tempProviderType = providerType
+                        // 개인정보 동의 바텀시트 표시
                         _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = true)
                     }.onFailure { exception ->
                         updateLoadingState(isLoading = false)
@@ -76,8 +84,23 @@ class LoginViewModel
          */
         fun onPrivacyConsentComplete() {
             viewModelScope.launch {
-                _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
-                _event.send(LoginEvent.NavigateToHome)
+                val accessToken = tempAccessToken
+                val providerType = tempProviderType
+
+                updateLoadingState(isLoading = true)
+                authRepository
+                    .socialLogin(accessToken!!, providerType!!)
+                    .onSuccess {
+                        updateLoadingState(isLoading = false)
+                        _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
+                        tempAccessToken = null
+                        tempProviderType = null
+                        _event.send(LoginEvent.NavigateToHome)
+                    }.onFailure { exception ->
+                        updateLoadingState(isLoading = false)
+                        _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
+                        _event.send(LoginEvent.ShowError(exception))
+                    }
             }
         }
 
@@ -86,6 +109,8 @@ class LoginViewModel
          */
         fun dismissPrivacyBottomSheet() {
             _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
+            tempAccessToken = null
+            tempProviderType = null
         }
 
         /**

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/LoginViewModel.kt
@@ -87,12 +87,20 @@ class LoginViewModel
                 val accessToken = tempAccessToken
                 val providerType = tempProviderType
 
+                // 프로세스 종료로 인한 데이터 유실 방어
+                if (accessToken == null || providerType == null) {
+                    _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
+                    _event.send(LoginEvent.ShowError(Exception("로그인 정보가 유실되었습니다. 다시 시도해주세요.")))
+                    return@launch
+                }
+
                 updateLoadingState(isLoading = true)
                 authRepository
-                    .socialLogin(accessToken!!, providerType!!)
+                    .socialLogin(accessToken, providerType)
                     .onSuccess {
                         updateLoadingState(isLoading = false)
                         _loginState.value = _loginState.value.copy(showPrivacyBottomSheet = false)
+                        // 임시 토큰 초기화
                         tempAccessToken = null
                         tempProviderType = null
                         _event.send(LoginEvent.NavigateToHome)

--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/main/MainActivity.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/main/MainActivity.kt
@@ -10,18 +10,27 @@ import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.alarmy.near.presentation.provider.ActivityContextProviderImpl
 import com.alarmy.near.presentation.ui.theme.NearTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val mainViewModel: MainViewModel by viewModels()
 
+    @Inject
+    lateinit var activityContextProvider: ActivityContextProviderImpl
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
 
         super.onCreate(savedInstanceState)
+
+        // Activity Context 설정
+        activityContextProvider.setActivityContext(this)
+
         enableEdgeToEdge()
         setupSplashScreen(splashScreen)
 
@@ -35,6 +44,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Activity Context 제거
+        activityContextProvider.setActivityContext(null)
     }
 
     /**

--- a/Near/app/src/main/java/com/alarmy/near/presentation/provider/ActivityContextProviderImpl.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/provider/ActivityContextProviderImpl.kt
@@ -1,0 +1,33 @@
+package com.alarmy.near.presentation.provider
+
+import android.content.Context
+import com.alarmy.near.data.provider.ActivityContextProvider
+import java.lang.ref.WeakReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Activity Context 제공 구현체
+ * MainActivity에서 직접 Context를 설정하는 방식
+ */
+@Singleton
+class ActivityContextProviderImpl
+    @Inject
+    constructor() : ActivityContextProvider {
+        private var activityContextRef: WeakReference<Context>? = null
+
+        /**
+         * Activity Context 설정
+         * MainActivity의 onCreate/onDestroy에서 호출됨
+         */
+        fun setActivityContext(context: Context?) {
+            activityContextRef =
+                if (context != null) {
+                    WeakReference(context)
+                } else {
+                    null
+                }
+        }
+
+        override fun getActivityContext(): Context? = activityContextRef?.get()
+    }


### PR DESCRIPTION
## 작업 내용

### 1. 카카오 로그인 시 카카오톡 앱 이동 기능 구현
- ApplicationContext 대신 ActivityContext를 사용하도록 변경
- ActivityContextProvider 패턴을 도입하여 Data Layer에서 Activity Context 사용
- MainActivity에서 ActivityContextProviderImpl에 Context 설정 및 해제

### 2. 로그인 플로우 개선
- 카카오 로그인 성공 시 즉시 서버 전송하지 않고 AccessToken만 임시 저장
- 개인정보 동의 완료 후 서버에 토큰 전송 및 DataStore에 저장
- 카카오톡 앱에서 취소 시 웹뷰로 fallback하지 않고 로그인 취소 처리

## 확인 방법

1. 카카오톡 설치 상태에서 로그인 버튼 클릭
2. 카카오톡 앱으로 이동하여 로그인
3. 로그인 성공 후 Near 앱으로 자동 복귀
4. 개인정보 동의 바텀시트에서 약관 동의 후 가입 버튼 클릭
5. 홈 화면으로 이동 확인

카카오톡 미설치 상태:
1. 로그인 버튼 클릭
2. 웹뷰로 로그인
3. 성공 후 Near 앱으로 복귀

## 참고 사항

### ActivityContext 주입 방식 선택

#### 문제 발생 과정
- 초기에는 `@ActivityContext` 어노테이션을 직접 사용하려 했으나, Hilt의 Component 계층 구조상 불가능했습니다.
- `@ActivityContext`는 ActivityComponent에서만 제공되는데, ActivityComponent의 클래스를 ViewModel에 주입할 수 없는 문제가 발생했습니다.
- ViewModel은 ViewModelComponent를 사용하며, ViewModelComponent는 ActivityRetainedComponent의 하위 컴포넌트입니다.
- ActivityComponent와 ActivityRetainedComponent는 서로 다른 생명주기와 스코프를 가지고 있어, ActivityScoped 클래스를 ActivityRetainedScoped나 Singleton 클래스에서 주입받을 수 없었습니다.

#### 해결 방안 검토
1. Context를 파라미터로 전달: 간단하지만 안드로이드 의존성의 간섭이 많아집니다.
2. ActivityContextProvider 패턴 도입: 최종 선택

#### 최종 해결 방법
- ActivityContextProvider 인터페이스를 Data Layer에 정의
- ActivityContextProviderImpl 구현체를 Presentation Layer에 배치하였습니다.
- MainActivity에서 onCreate/onDestroy 시점에 ActivityContextProviderImpl에 Context를 설정/해제

## 관련 이슈
- close #49 