### PR TITLE
[FIX] 카카오톡 미로그인 시 소셜로그인 안되는 현상 수정

### DIFF
--- a/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/auth/KakaoLoginManager.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/feature/login/auth/KakaoLoginManager.kt
@@ -6,6 +6,7 @@ import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ApiError
 import com.kakao.sdk.common.model.AuthError
 import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.common.model.KakaoSdkError
 import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.CancellableContinuation
@@ -28,22 +29,20 @@ class KakaoLoginManager(
     ) {
         unlinkKakao()
         try {
-            val accessToken =
-                if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-                    loginWithKakaoTalk()
-                } else {
-                    loginWithKakaoAccount()
-                }
+            val accessToken = fetchAccessToken()
             onSuccess(accessToken)
+        } catch (error: ClientError) {
+            if (error.reason == ClientErrorCause.Cancelled) {
+                onFailure(Exception(context.getString(R.string.login_user_cancelled)))
+            } else {
+                onFailure(Exception(context.getString(R.string.login_client_error)))
+            }
         } catch (error: AuthError) {
             // OAuth 인증 과정 에러
             onFailure(Exception(context.getString(R.string.login_auth_error)))
         } catch (error: ApiError) {
             // API 호출 에러
             onFailure(Exception(context.getString(R.string.login_api_error)))
-        } catch (error: ClientError) {
-            // SDK 내부 에러
-            onFailure(Exception(context.getString(R.string.login_client_error)))
         } catch (error: KakaoSdkError) {
             // 카카오 SDK 에러
             onFailure(Exception(context.getString(R.string.login_sdk_error)))
@@ -84,6 +83,17 @@ class KakaoLoginManager(
             }
         }
 
+    private suspend fun fetchAccessToken(): String {
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context).not()) {
+            return loginWithKakaoAccount()
+        }
+        return runCatching { loginWithKakaoTalk() }
+            .getOrElse {
+                // 카카오톡 로그인 단계에서 실패하면 즉시 웹 계정 로그인으로 폴백
+                loginWithKakaoAccount()
+            }
+    }
+
     // 카카오 로그인 결과 처리
     private fun handleLoginResult(
         token: OAuthToken?,
@@ -91,21 +101,17 @@ class KakaoLoginManager(
         continuation: CancellableContinuation<String>,
     ) {
         when {
-            error != null -> {
-                continuation.resumeWith(
-                    Result.failure(
-                        Exception(context.getString(R.string.login_user_cancelled)),
-                    ),
-                )
-            }
             token != null -> continuation.resume(token.accessToken)
-            else -> {
+            error != null ->
+                continuation.resumeWith(
+                    Result.failure(error),
+                )
+            else ->
                 continuation.resumeWith(
                     Result.failure(
                         Exception(context.getString(R.string.login_user_cancelled)),
                     ),
                 )
-            }
         }
     }
 }


### PR DESCRIPTION

## 작업 내용
- 카카오톡 앱으로 로그인을 시도하다가 실패하거나 사용자가 취소할 경우, 
별도의 에러 메시지 없이 바로 카카오계정(웹) 로그인으로 전환되도록 로직을 개선했습니다.
- 사용자가 로그인을 취소했을 때 발생하는 `ClientError`를 `KakaoUserCancelledException`으로 매핑하여 처리합니다.


## 확인 방법
KakaoLoginManager에서 확인하실 수 있습니다.
카카오톡을 설치후 로그인하지 않고 소셜로그인을 수행하면 wb으로 redirect됩니다.

## 관련 이슈
- close #62 
