### PR TITLE
[QA] 주기설정 바텀시트 텍스트 크기 수정

### DIFF
--- a/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/bottomsheet/CycleSettingBottomSheet.kt
+++ b/Near/app/src/main/java/com/alarmy/near/presentation/ui/component/bottomsheet/CycleSettingBottomSheet.kt
@@ -151,13 +151,14 @@ fun CycleSettingBottomSheet(
                             if (!isSelected) {
                                 selectedInterval = interval
                             }
-                        }.padding(vertical = 15.dp),
+                        },
             ) {
                 Text(
+                    modifier = Modifier.padding(vertical = 15.dp),
                     text = stringResource(interval.labelRes),
                     style =
                         if (isSelected) {
-                            NearTheme.typography.B1_16_BOLD
+                            NearTheme.typography.B2_14_BOLD
                         } else {
                             NearTheme.typography.B2_14_MEDIUM
                         },


### PR DESCRIPTION

## 작업 내용
- 주기 설정 바텀시트에서 선택된 항목의 텍스트 스타일을 `B1_16_BOLD`에서 `B2_14_BOLD`로 변경했습니다.
- `Row`에 적용되었던 `padding`을 내부 `Text` 컴포넌트로 이동하였습니다.


## 확인 방법
- presentation.ui.component.bottomsheet CycleSettingBottomSheet에서
```kotlin
                    style =
                        if (isSelected) {
                            NearTheme.typography.B2_14_BOLD
                        } else {
                            NearTheme.typography.B2_14_MEDIUM
                        },
```
로 변경하였습니다.